### PR TITLE
fix: dependabot lockfile sync and skip Vercel previews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/app' # Location of package manifests
+    directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "if [[ \"$VERCEL_GIT_COMMIT_REF\" == dependabot/* ]]; then exit 0; fi; exit 1"
+}


### PR DESCRIPTION
## Summary

- Fix dependabot `directory` (`/app` → `/`) so `package-lock.json` gets updated in dependabot PRs
- Add `vercel.json` with `ignoreCommand` to skip preview deployments for `dependabot/*` branches

## Test plan
- [ ] Vérifier que les prochaines PRs dependabot incluent le lock file mis à jour
- [ ] Vérifier que les branches dependabot ne déclenchent plus de preview Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)