### PR TITLE
feat(cv): split old missions with display:false for tech year calculation

### DIFF
--- a/app/[lang]/dev/components/page.tsx
+++ b/app/[lang]/dev/components/page.tsx
@@ -134,7 +134,9 @@ export default async function DevComponentsPage({
 
   // Variante « short » des missions : même filtre/limite que CompactCvLayout
   // (`SHORT_CV_EXCLUDED_CLIENTS`, `SHORT_CV_MAX_JOBS`) + bloc de clôture.
-  const allJobs: any[] = data?.allJobsModels || [];
+  const allJobs: any[] = (data?.allJobsModels || []).filter(
+    (j: { display?: boolean }) => j.display !== false,
+  );
   const closing = getExperienceClosingLabels(lang);
   const moreClientsLine = formatRemainingClientsForShortCv(allJobs, lang);
   const recentJobs = allJobs

--- a/app/[lang]/jobs.tsx
+++ b/app/[lang]/jobs.tsx
@@ -11,8 +11,11 @@ import React from 'react';
 export default async function jobs({ locale }: { locale: Locale }) {
   const data: any = await getCvData(locale);
   const jobsList = data?.allJobsModels || [];
+  const visibleJobs = jobsList.filter(
+    (j: { display?: boolean }) => j.display !== false,
+  );
   const closing = getExperienceClosingLabels(locale);
-  const recapLine = formatRemainingClientsRecapForFullCv(jobsList, locale);
+  const recapLine = formatRemainingClientsRecapForFullCv(visibleJobs, locale);
 
   return (
     <div className="cv-print-jobs-group print-preview:order-[90] print:order-[90]">
@@ -24,13 +27,13 @@ export default async function jobs({ locale }: { locale: Locale }) {
           {data?.jobsTitle?.title}
         </h2>
         <ul className="cv-section-body-gap space-y-4 print:space-y-4">
-          {jobsList.map((job: any, index: number) => (
+          {visibleJobs.map((job: any, index: number) => (
             <li key={job.client + index}>
               <Job job={job} locale={locale} />
             </li>
           ))}
         </ul>
-        {jobsList.length > 0 ? (
+        {visibleJobs.length > 0 ? (
           <ExperienceClosingBlock
             moreExperience={closing.moreExperience}
             moreExperienceTail={closing.moreExperienceTail}

--- a/app/[lang]/short/page.tsx
+++ b/app/[lang]/short/page.tsx
@@ -89,22 +89,24 @@ export default async function ShortPage({
       description: resolveDomainDescription(d, contract),
       competencies: d.competencies || [],
     })),
-    jobs: (data?.allJobsModels || []).map((j: any) => {
-      const dates = formatDates(j.startDate, j.endDate);
-      const [start, end] = dates ? dates.split(' - ') : ['', ''];
-      return {
-        client: j.client,
-        clientUrl: j.clientUrl,
-        role: j.role?.name || '',
-        location: j.location,
-        startDate: start || '',
-        endDate: end || undefined,
-        description: j.description,
-        descriptionShort: j.descriptionShort,
-        bullets: j.bullets,
-        frameworks: j.frameworks || [],
-      };
-    }),
+    jobs: (data?.allJobsModels || [])
+      .filter((j: { display?: boolean }) => j.display !== false)
+      .map((j: any) => {
+        const dates = formatDates(j.startDate, j.endDate);
+        const [start, end] = dates ? dates.split(' - ') : ['', ''];
+        return {
+          client: j.client,
+          clientUrl: j.clientUrl,
+          role: j.role?.name || '',
+          location: j.location,
+          startDate: start || '',
+          endDate: end || undefined,
+          description: j.description,
+          descriptionShort: j.descriptionShort,
+          bullets: j.bullets,
+          frameworks: j.frameworks || [],
+        };
+      }),
     studies: sortChronologicalDesc(
       (data?.allStudiesModels || []).map((s: any) => ({
         ...s,

--- a/data/cv/bundle.json
+++ b/data/cv/bundle.json
@@ -1688,18 +1688,130 @@
         "descriptionShort": "Activités d'études et développement d'un outil intranet de contractualisation des produits de type imprimés publicitaires proposés par LA POSTE dans ses établissements"
       },
       {
-        "client": "Renault / BNP Paribas / La compagnie 1818 / DGFIP / SFR",
-        "location": "Paris",
-        "startDate": "2004-09-01",
+        "display": false,
+        "client": "SFR",
+        "location": "Nanterre Rive Défense",
+        "startDate": "2010-04-01",
         "endDate": "2011-03-01",
-        "description": "",
+        "description": "Activités de développement au sein de SFR, dans le cadre de la gestion du workflow fibre optique",
         "bullets": [],
-        "frameworks": [],
+        "frameworks": [
+          { "id": "82460503", "name": "java 5", "link": "" },
+          { "id": "78726170", "name": "Maven 2", "link": "" },
+          { "id": "91050015", "name": "EJB 2.1", "link": "" },
+          { "id": "91050016", "name": "MDA", "link": "" },
+          { "id": "91050013", "name": "JBoss 4", "link": "" },
+          { "id": "91050017", "name": "Mule ESB", "link": "" },
+          { "id": "91050018", "name": "JBPM", "link": "" },
+          { "id": "91050019", "name": "Drools", "link": "" },
+          { "id": "82456040", "name": "Git", "link": "" }
+        ],
+        "role": {
+          "name": "Consultant Backend",
+          "id": "82089336"
+        },
+        "descriptionShort": "Gestion du workflow fibre optique, développement SOA"
+      },
+      {
+        "display": false,
+        "client": "DGFIP",
+        "location": "Noisy-le-Grand",
+        "startDate": "2008-10-01",
+        "endDate": "2010-04-01",
+        "description": "Activités d'études, développement et maintien en conditions opérationnelles des projets ADP et SVC assurant la mise en œuvre de la signature électronique et l'archivage de la preuve dans le cadre des procédures de télé-déclaration de la TVA et des impôts sur les revenus au sein de la Direction Générale des Finances Publiques",
+        "bullets": [],
+        "frameworks": [
+          { "id": "82460503", "name": "java 5", "link": "" },
+          { "id": "78726170", "name": "Maven 2", "link": "" },
+          { "id": "91050010", "name": "EJB 3", "link": "" },
+          { "id": "91050011", "name": "JAXB", "link": "" },
+          { "id": "91050012", "name": "JAX-WS", "link": "" },
+          { "id": "91050013", "name": "JBoss 4", "link": "" },
+          { "id": "78726310", "name": "Apache", "link": "" },
+          { "id": "91050014", "name": "Oracle 9i", "link": "" }
+        ],
+        "role": {
+          "name": "Consultant Backend",
+          "id": "82089336"
+        },
+        "descriptionShort": "Signature électronique et archivage de preuves pour la télé-déclaration"
+      },
+      {
+        "display": false,
+        "client": "La Compagnie 1818",
+        "location": "Paris",
+        "startDate": "2008-02-01",
+        "endDate": "2008-09-01",
+        "description": "Activités de développement et maintenance sur l'ensemble du site web destiné aux entreprises et aux clients",
+        "bullets": [],
+        "frameworks": [
+          { "id": "90601531", "name": "Java", "link": "" },
+          { "id": "91050008", "name": "JSF", "link": "" },
+          { "id": "91050009", "name": "Machines virtuelles", "link": "" }
+        ],
         "role": {
           "name": "Consultant Full Stack",
           "id": "81994135"
         },
-        "descriptionShort": "Toutes mes précédentes missions dont je peux fournir le détail sur demande"
+        "descriptionShort": "Développement et maintenance du site web entreprises et clients"
+      },
+      {
+        "display": false,
+        "client": "BNP Paribas",
+        "location": "Montreuil - Valmy2",
+        "startDate": "2006-10-01",
+        "endDate": "2008-01-01",
+        "description": "Activités d'études, développement et tierce maintenance applicative sur les projets Certification, RPS et PKI dans le cadre du centre de services mis en place par ALTI",
+        "bullets": [],
+        "frameworks": [
+          { "id": "90601531", "name": "Java", "link": "" },
+          { "id": "91050004", "name": "WebSphere", "link": "" },
+          { "id": "91050005", "name": "Struts", "link": "" },
+          { "id": "91050006", "name": "JavaScript", "link": "" },
+          { "id": "91050007", "name": "CSS", "link": "" }
+        ],
+        "role": {
+          "name": "Consultant Full Stack",
+          "id": "81994135"
+        },
+        "descriptionShort": "Certification, RPS et PKI au sein du centre de services"
+      },
+      {
+        "display": false,
+        "client": "Renault SA",
+        "location": "Guyancourt",
+        "startDate": "2005-10-01",
+        "endDate": "2006-09-01",
+        "description": "Développement d'un outil statistique de prévisions de vente de véhicules Renault dans le cadre de ma licence",
+        "bullets": [],
+        "frameworks": [
+          { "id": "90601531", "name": "Java", "link": "" },
+          { "id": "91050002", "name": "Excel", "link": "" },
+          { "id": "91050003", "name": "C++", "link": "" }
+        ],
+        "role": {
+          "name": "Consultant Backend",
+          "id": "82089336"
+        },
+        "descriptionShort": "Outil statistique de prévisions de vente de véhicules"
+      },
+      {
+        "display": false,
+        "client": "CFA SUP 2000",
+        "location": "Saint-Maurice",
+        "startDate": "2004-09-01",
+        "endDate": "2005-08-01",
+        "description": "Refonte informatique de l'outil de gestion du CFA dans le cadre de mon DUT",
+        "bullets": [],
+        "frameworks": [
+          { "id": "90601531", "name": "Java", "link": "" },
+          { "id": "91050001", "name": "RMI", "link": "" }
+        ],
+        "role": {
+          "name": "Consultant Full Stack",
+          "id": "81994135"
+        },
+        "descriptionShort": "Refonte de l'outil de gestion du CFA"
       }
     ],
     "allStudiesModels": [
@@ -3803,18 +3915,130 @@
         "descriptionShort": "Study activities and development of an intranet tool for contractualisation of printed advertising products offered by LA POSTE in its establishments"
       },
       {
-        "client": "Renault / BNP Paribas / La compagnie 1818 / DGFIP / SFR",
-        "location": "Paris",
-        "startDate": "2004-09-01",
+        "display": false,
+        "client": "SFR",
+        "location": "Nanterre Rive Défense",
+        "startDate": "2010-04-01",
         "endDate": "2011-03-01",
-        "description": "I can provide all information on demand",
+        "description": "Development activities within SFR, as part of the management of the optical fiber workflow",
         "bullets": [],
-        "frameworks": [],
+        "frameworks": [
+          { "id": "82460503", "name": "java 5", "link": "" },
+          { "id": "78726170", "name": "Maven 2", "link": "" },
+          { "id": "91050015", "name": "EJB 2.1", "link": "" },
+          { "id": "91050016", "name": "MDA", "link": "" },
+          { "id": "91050013", "name": "JBoss 4", "link": "" },
+          { "id": "91050017", "name": "Mule ESB", "link": "" },
+          { "id": "91050018", "name": "JBPM", "link": "" },
+          { "id": "91050019", "name": "Drools", "link": "" },
+          { "id": "82456040", "name": "Git", "link": "" }
+        ],
         "role": {
           "name": "Backend Consultant",
           "id": "82089336"
         },
-        "descriptionShort": "All my previous jobs."
+        "descriptionShort": "Optical fiber workflow management, SOA development"
+      },
+      {
+        "display": false,
+        "client": "DGFIP",
+        "location": "Noisy-le-Grand",
+        "startDate": "2008-10-01",
+        "endDate": "2010-04-01",
+        "description": "Activities of studies, development and maintenance in operational condition of ADP and SVC projects which ensure the implementation of the electronic signature and the archiving of the proof within the framework of the procedures of tele-declaration of the VAT and the taxes on revenues within the General Finance Department",
+        "bullets": [],
+        "frameworks": [
+          { "id": "82460503", "name": "java 5", "link": "" },
+          { "id": "78726170", "name": "Maven 2", "link": "" },
+          { "id": "91050010", "name": "EJB 3", "link": "" },
+          { "id": "91050011", "name": "JAXB", "link": "" },
+          { "id": "91050012", "name": "JAX-WS", "link": "" },
+          { "id": "91050013", "name": "JBoss 4", "link": "" },
+          { "id": "78726310", "name": "Apache", "link": "" },
+          { "id": "91050014", "name": "Oracle 9i", "link": "" }
+        ],
+        "role": {
+          "name": "Backend Consultant",
+          "id": "82089336"
+        },
+        "descriptionShort": "Electronic signature and proof archiving for tax tele-declaration"
+      },
+      {
+        "display": false,
+        "client": "La Compagnie 1818",
+        "location": "Paris",
+        "startDate": "2008-02-01",
+        "endDate": "2008-09-01",
+        "description": "Development and maintenance activities for the entire website for businesses and customers",
+        "bullets": [],
+        "frameworks": [
+          { "id": "90601531", "name": "Java", "link": "" },
+          { "id": "91050008", "name": "JSF", "link": "" },
+          { "id": "91050009", "name": "Virtual Machines", "link": "" }
+        ],
+        "role": {
+          "name": "Full Stack Consultant",
+          "id": "81994135"
+        },
+        "descriptionShort": "Business and customer website development and maintenance"
+      },
+      {
+        "display": false,
+        "client": "BNP Paribas",
+        "location": "Montreuil - Valmy2",
+        "startDate": "2006-10-01",
+        "endDate": "2008-01-01",
+        "description": "Study, development and third-party application maintenance activities on Certification, RPS and PKI projects as part of the service center set up by ALTI",
+        "bullets": [],
+        "frameworks": [
+          { "id": "90601531", "name": "Java", "link": "" },
+          { "id": "91050004", "name": "WebSphere", "link": "" },
+          { "id": "91050005", "name": "Struts", "link": "" },
+          { "id": "91050006", "name": "JavaScript", "link": "" },
+          { "id": "91050007", "name": "CSS", "link": "" }
+        ],
+        "role": {
+          "name": "Full Stack Consultant",
+          "id": "81994135"
+        },
+        "descriptionShort": "Certification, RPS and PKI within the service center"
+      },
+      {
+        "display": false,
+        "client": "Renault SA",
+        "location": "Guyancourt",
+        "startDate": "2005-10-01",
+        "endDate": "2006-09-01",
+        "description": "Development of a statistical tool for Renault vehicle sales forecasts as part of my license",
+        "bullets": [],
+        "frameworks": [
+          { "id": "90601531", "name": "Java", "link": "" },
+          { "id": "91050002", "name": "Excel", "link": "" },
+          { "id": "91050003", "name": "C++", "link": "" }
+        ],
+        "role": {
+          "name": "Backend Consultant",
+          "id": "82089336"
+        },
+        "descriptionShort": "Statistical tool for vehicle sales forecasts"
+      },
+      {
+        "display": false,
+        "client": "CFA SUP 2000",
+        "location": "Saint-Maurice",
+        "startDate": "2004-09-01",
+        "endDate": "2005-08-01",
+        "description": "Computer overhaul of the CFA management tool as part of my technological university degree",
+        "bullets": [],
+        "frameworks": [
+          { "id": "90601531", "name": "Java", "link": "" },
+          { "id": "91050001", "name": "RMI", "link": "" }
+        ],
+        "role": {
+          "name": "Full Stack Consultant",
+          "id": "81994135"
+        },
+        "descriptionShort": "CFA management tool overhaul"
       }
     ],
     "allStudiesModels": [


### PR DESCRIPTION
## Changes

- **CV Data**: Split combined old missions (2004-2011) into individual entries with `display: false` flag
  - Separated 6 distinct missions: CFA SUP 2000, Renault SA, BNP Paribas, La Compagnie 1818, DGFIP, and SFR
  - Each mission now has complete details (dates, frameworks, descriptions, roles, locations)
  - Added English translations for all missions

- **Display Logic**: Updated job filtering across all pages to respect `display` flag
  - `app/[lang]/jobs.tsx`: Filter jobs before rendering and calculating summaries
  - `app/[lang]/short/page.tsx`: Filter jobs in the short CV layout
  - `app/[lang]/dev/components/page.tsx`: Filter jobs for component preview

- **Purpose**: Allows archiving old missions while maintaining historical data for technology year calculations without cluttering the public CV display