### PR TITLE
ci: auto-sync package-lock.json on main after merges

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -29,11 +29,25 @@ jobs:
           node-version: '20'
           cache: npm
 
-      - name: Verify lock file is in sync
+      - name: Sync lock file
+        run: npm install --package-lock-only
+
+      - name: Auto-fix lock file (main only)
+        if: github.ref == 'refs/heads/main'
         run: |
-          npm install --package-lock-only
+          if ! git diff --quiet package-lock.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add package-lock.json
+            git commit -m "chore: auto-sync package-lock.json"
+            git push
+          fi
+
+      - name: Verify lock file is in sync (PRs only)
+        if: github.event_name == 'pull_request'
+        run: |
           git diff --exit-code package-lock.json || \
-            (echo "::error::package-lock.json is out of sync with package.json. Run 'npm install' and commit the lock file." && exit 1)
+            (echo "::error::package-lock.json is out of sync. Run 'npm install' and commit the lock file." && exit 1)
 
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -10193,6 +10193,22 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/postcss-loader/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/postcss-modules-extract-imports": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",


### PR DESCRIPTION
## Summary

- **Sur main** : si le lock file est désynchronisé après un merge dependabot, le CI le corrige et commit automatiquement
- **Sur PRs** : garde le check existant qui signale l'erreur sans auto-fix
- Inclut la regénération du lock file pour fixer la désync actuelle

## Fonctionnement

```
push to main → npm install --package-lock-only → diff? → auto-commit fix
pull request → npm install --package-lock-only → diff? → erreur CI
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)