### PR TITLE
fix(cv): add missing frameworks to BlaBlaCar, Smartch and Médiapost

### DIFF
--- a/app/api/llm-guide/route.ts
+++ b/app/api/llm-guide/route.ts
@@ -69,6 +69,19 @@ Chaque valeur suit le pattern \`Label:keyword1,keyword2\` :
 
 Les mots-cles texte fonctionnent aussi (matching insensible a la ponctuation).
 
+### Calcul automatique des annees d'experience
+
+Pour chaque requirement, le systeme cherche les missions dont les frameworks,
+role, description ou puces contiennent un des keywords (matching insensible
+a la casse et a la ponctuation : "vuejs" matche "Vue.js").
+
+Les annees affichees = somme des durees des missions matchees (deduplication
+par client). Pour maximiser la precision, inclure tous les mots-cles
+pertinents (ex : pour Frontend, inclure react,angular,vuejs,ionic,gwt,jsf,
+javascript,typescript plutot que juste react).
+
+Si le calcul auto ne convient pas, utiliser \`reqY\` pour forcer une valeur.
+
 ### Type de contrat
 
 - \`contract=cdi\` : textes profil et domaines adaptes pour un poste permanent, lien Malt masque.

--- a/data/cv/bundle.json
+++ b/data/cv/bundle.json
@@ -409,6 +409,11 @@
             "id": "82456128",
             "name": "Kubernetes",
             "link": ""
+          },
+          {
+            "id": "90601531",
+            "name": "Java",
+            "link": ""
           }
         ],
         "role": {
@@ -442,6 +447,11 @@
           {
             "id": "82455959",
             "name": "Kotlin",
+            "link": ""
+          },
+          {
+            "id": "90601531",
+            "name": "Java",
             "link": ""
           },
           {
@@ -1679,6 +1689,11 @@
             "id": "82627945",
             "name": "pair programming",
             "link": ""
+          },
+          {
+            "id": "91050008",
+            "name": "JSF",
+            "link": ""
           }
         ],
         "role": {
@@ -2636,6 +2651,11 @@
             "id": "82456128",
             "name": "Kubernetes",
             "link": ""
+          },
+          {
+            "id": "90601531",
+            "name": "Java",
+            "link": ""
           }
         ],
         "role": {
@@ -2669,6 +2689,11 @@
           {
             "id": "82455959",
             "name": "Kotlin",
+            "link": ""
+          },
+          {
+            "id": "90601531",
+            "name": "Java",
             "link": ""
           },
           {
@@ -3905,6 +3930,11 @@
           {
             "id": "82627945",
             "name": "pair programming",
+            "link": ""
+          },
+          {
+            "id": "91050008",
+            "name": "JSF",
             "link": ""
           }
         ],


### PR DESCRIPTION
## Summary

- **BlaBlaCar**: add Java (used with Spring Boot)
- **Smartch**: add Java (used alongside Kotlin)
- **Médiapost**: add JSF (frontend framework used on this mission)

These additions improve accuracy of technology year calculations, especially for Java and Frontend requirements matching.

## Test plan

- [ ] Verify BlaBlaCar, Smartch and Médiapost display the new frameworks on the CV
- [ ] Test URL with `requirement=Java:java` includes BlaBlaCar and Smartch
- [ ] Test URL with `requirement=Frontend:jsf` includes Médiapost

🤖 Generated with [Claude Code](https://claude.com/claude-code)