### PR TITLE
feat: add subtitle URL params and enhance job fit display

### DIFF
--- a/app/[lang]/header.tsx
+++ b/app/[lang]/header.tsx
@@ -8,6 +8,7 @@ export default async function Header({
   locale,
   offerPrintContactStrip,
   hideMalt,
+  subtitleOverride,
 }: {
   locale: Locale;
   /** Pages offre : bandeau coordonnées sous le rôle uniquement en aperçu `?print`. */
@@ -17,6 +18,8 @@ export default async function Header({
     location: string;
   };
   hideMalt?: boolean;
+  /** Surcharge du sous-titre (rôle) via paramètre URL. */
+  subtitleOverride?: string;
 }) {
   const data: any = await getCvData(locale);
 
@@ -26,7 +29,10 @@ export default async function Header({
         <HeaderToolbar hideMalt={hideMalt} />
       </div>
 
-      <HeaderContent name={data?.header?.name} role={data?.header?.role} />
+      <HeaderContent
+        name={data?.header?.name}
+        role={subtitleOverride || data?.header?.role}
+      />
     </header>
   );
 }

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -61,6 +61,11 @@ export default async function Page({
     offer,
     sp,
   );
+  const subtitleOverride =
+    (lang === 'fr'
+      ? sp.get('subtitle_fr') || sp.get('subtitle')
+      : sp.get('subtitle_en') || sp.get('subtitle')
+    )?.trim() || undefined;
   const contact = data.contact as
     | { email?: string; phone?: string; location?: string }
     | undefined;
@@ -78,6 +83,7 @@ export default async function Page({
       contactLocation={contactLocation}
       hideMalt={contract === 'cdi'}
       contract={contract}
+      subtitleOverride={subtitleOverride}
     />
   );
 }

--- a/app/[lang]/short/page.tsx
+++ b/app/[lang]/short/page.tsx
@@ -53,6 +53,17 @@ export default async function ShortPage({
       : undefined;
   const hideMalt = contract === 'cdi';
 
+  const sp = new URLSearchParams(
+    Object.entries(searchParams ?? {}).flatMap(([k, v]) =>
+      Array.isArray(v) ? v.map((val) => [k, val]) : v != null ? [[k, v]] : [],
+    ),
+  );
+  const subtitleOverride =
+    (lang === 'fr'
+      ? sp.get('subtitle_fr') || sp.get('subtitle')
+      : sp.get('subtitle_en') || sp.get('subtitle')
+    )?.trim() || undefined;
+
   // Missions mises en avant par le LLM (param `job`, répétable)
   const jobParam = searchParams?.job;
   const highlightedJobSlugs: string[] | undefined = jobParam
@@ -64,7 +75,7 @@ export default async function ShortPage({
   const compactData: CompactCvData = {
     header: {
       name: data?.header?.name || '',
-      role: data?.header?.role || '',
+      role: subtitleOverride || data?.header?.role || '',
     },
     titles: {
       about: data?.about?.title || '',
@@ -136,7 +147,7 @@ export default async function ShortPage({
       <ShortPageWrapper
         lang={lang}
         headerName={data?.header?.name || ''}
-        headerRole={data?.header?.role || ''}
+        headerRole={subtitleOverride || data?.header?.role || ''}
         hideMalt={hideMalt}
       >
         <Suspense fallback={null}>

--- a/app/api/llm-guide/route.ts
+++ b/app/api/llm-guide/route.ts
@@ -50,6 +50,9 @@ GET /{lang}?company=<nom>&requirement=<Label:kw1,kw2>[&...]
 | \`title\` | non | Intitule du poste (FR et EN si seul titre fourni) |
 | \`title_fr\` | non | Titre affiche cote francais |
 | \`title_en\` | non | Titre affiche cote anglais |
+| \`subtitle\` | non | Sous-titre / role affiche sous le nom (FR et EN si seul subtitle fourni) |
+| \`subtitle_fr\` | non | Sous-titre affiche cote francais (ex. "Chef de Projet Java Full Stack") |
+| \`subtitle_en\` | non | Sous-titre affiche cote anglais (ex. "Java Full Stack Project Manager") |
 | \`requirement\` | **oui** (1+) | Repetable. Format : \`Label:keyword1,keyword2\` |
 | \`req\` | alias | Alias court pour \`requirement\` |
 | \`reqY\` | non | Annees d'experience affichees pour le i-eme requirement (remplace le calcul auto) |
@@ -87,11 +90,32 @@ Si le calcul auto ne convient pas, utiliser \`reqY\` pour forcer une valeur.
 - \`contract=cdi\` : textes profil et domaines adaptes pour un poste permanent, lien Malt masque.
 - \`contract=freelance\` : textes freelance (comportement par defaut).
 
+### Ordre des requirements
+
+**L'ordre des parametres \`requirement\` dans l'URL determine l'ordre d'affichage
+dans la section "Adequation poste".** Le LLM doit ordonner les requirements
+par pertinence vis-a-vis de l'offre : placer les competences les plus
+importantes ou les plus demandees en premier. En mode short (CV court),
+seules les **${SHORT_PROFILE_MATCH_MAX} premieres** sont affichees.
+
+Conseil : placer en premier les competences coeur de l'offre (ex. Java pour
+un poste Java), puis les competences secondaires (SQL, Docker, etc.).
+
+### Sous-titre du CV
+
+Par defaut, le sous-titre affiche "Developpeur fullstack Senior" (FR) /
+"Senior Fullstack Developer" (EN). Pour l'adapter a l'offre, utiliser
+\`subtitle_fr\` et/ou \`subtitle_en\` (ou \`subtitle\` pour les deux langues).
+
+Exemple : \`subtitle_fr=Chef+de+Projet+Java+Full+Stack&subtitle_en=Java+Full+Stack+Project+Manager\`
+
 ## Vignettes adequation poste
 
 - 1 vignette education (toujours affichee) : "Bac+5" (FR) / "Master's-level" (EN).
 - Max **${SHORT_PROFILE_MATCH_MAX}** vignettes technologiques en mode short.
 - Pas de limite en mode full (CV complet).
+- En mode short, chaque vignette indique le nombre de clients (missions).
+- En mode full, la liste detaillee des clients est affichee sous chaque vignette.
 
 ## Catalogue de technologies disponibles
 
@@ -127,7 +151,7 @@ Exemple :
 ### CV adapte poste CDI Java/Cloud
 
 \`\`\`
-/fr?company=Entreprise&title=Developpeur+Java+Senior&requirement=Java:java,spring&requirement=Cloud:aws,docker&contract=cdi
+/fr?company=Entreprise&title=Developpeur+Java+Senior&subtitle_fr=Developpeur+Java+Senior&requirement=Java:java,spring&requirement=Cloud:aws,docker&contract=cdi
 \`\`\`
 
 ### CV adapte mission freelance React

--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -5,7 +5,10 @@ import {
   type MatchYearsLang,
 } from '@/lib/format-match-years';
 import { useShortOfferMatchData } from '@/lib/use-short-offer-match-data';
-import { computeDefaultMatchData } from '@/lib/short-offer-match';
+import {
+  computeDefaultMatchData,
+  SHORT_PROFILE_MATCH_MAX,
+} from '@/lib/short-offer-match';
 import type { EducationLevelContent } from '@/lib/education-level-content';
 import type { MatchDisplayData } from '@/lib/match-display-types';
 import type { Locale } from 'i18n-config';
@@ -35,7 +38,10 @@ export default function JobFitSection({
   const defaults = useMemo(() => computeDefaultMatchData(lang), [lang]);
 
   const data: MatchDisplayData = offerData ?? defaults;
-  const entries = data.entries;
+  const entries =
+    variant === 'compact'
+      ? data.entries.slice(0, SHORT_PROFILE_MATCH_MAX)
+      : data.entries;
   const l = lang as MatchYearsLang;
 
   const sectionTitle = lang === 'en' ? 'Job fit' : 'Adequation poste';
@@ -55,19 +61,26 @@ export default function JobFitSection({
 
           {/* Tech pills */}
           {entries.map((entry, index) => {
+            const clientCount = entry.matchedClients.length;
             const showYears =
-              entry.matchedClients.length > 0 ||
-              entry.yearsFromOverride === true;
+              clientCount > 0 || entry.yearsFromOverride === true;
             const yearsLabel = showYears
               ? formatMatchYears(entry.totalYears, l)
               : '\u2014';
+            const clientsLabel =
+              clientCount > 0
+                ? `${clientCount} ${clientCount === 1 ? 'client' : 'clients'}`
+                : undefined;
+            const metric = clientsLabel
+              ? `${yearsLabel} · ${clientsLabel}`
+              : yearsLabel;
 
             return (
               <Pill
                 key={`${index}-${entry.label}`}
                 color="match"
                 compact
-                metric={yearsLabel}
+                metric={metric}
               >
                 {entry.label}
               </Pill>

--- a/components/OfferTailoredShell.tsx
+++ b/components/OfferTailoredShell.tsx
@@ -31,6 +31,7 @@ export default function OfferTailoredShell({
   contactLocation,
   hideMalt,
   contract,
+  subtitleOverride,
 }: {
   lang: Locale;
   educationLevel: EducationLevelContent;
@@ -48,6 +49,8 @@ export default function OfferTailoredShell({
   hideMalt?: boolean;
   /** Type de contrat : adapte les textes Profil et Domaines. */
   contract?: ContractType;
+  /** Surcharge du sous-titre (rôle) dans l'en-tête. */
+  subtitleOverride?: string;
 }) {
   const resolvedContact: ContactLocationOverlay = contactLocation ?? {
     mapsHref: buildContactLocationHref(),
@@ -68,6 +71,7 @@ export default function OfferTailoredShell({
             locale={lang}
             offerPrintContactStrip={headerContactStrip}
             hideMalt={hideMalt}
+            subtitleOverride={subtitleOverride}
           />
 
           <div className="cv-full-cv-print-root">

--- a/components/ShortHeaderJobFitPills.tsx
+++ b/components/ShortHeaderJobFitPills.tsx
@@ -5,6 +5,7 @@ import {
   type MatchYearsLang,
 } from '@/lib/format-match-years';
 import { useShortOfferMatchData } from '@/lib/use-short-offer-match-data';
+import { SHORT_PROFILE_MATCH_MAX } from '@/lib/short-offer-match';
 import Pill from '@/components/Pill';
 import type { Locale } from 'i18n-config';
 
@@ -20,7 +21,7 @@ export default function ShortHeaderJobFitPills({
   lang,
 }: ShortHeaderJobFitPillsProps) {
   const data = useShortOfferMatchData(lang);
-  const entries = data?.entries ?? [];
+  const entries = (data?.entries ?? []).slice(0, SHORT_PROFILE_MATCH_MAX);
   const l = lang as MatchYearsLang;
   if (entries.length === 0) return null;
 

--- a/data/cv/bundle.json
+++ b/data/cv/bundle.json
@@ -109,6 +109,16 @@
         "id": "skill_hexa_tc2026",
         "name": "Architecture hexagonale",
         "link": "https://alistair.cockburn.us/hexagonal-architecture/"
+      },
+      {
+        "id": "skill_nodejs_tc2026",
+        "name": "Node.js",
+        "link": "https://nodejs.org/"
+      },
+      {
+        "id": "skill_nestjs_tc2026",
+        "name": "NestJS",
+        "link": "https://nestjs.com/"
       }
     ],
     "allDomainsModels": [
@@ -300,6 +310,16 @@
             "id": "82518980",
             "name": "Matière Web",
             "link": "https://matiere-web.com/"
+          },
+          {
+            "id": "skill_nodejs_tc2026",
+            "name": "Node.js",
+            "link": "https://nodejs.org/"
+          },
+          {
+            "id": "skill_nestjs_tc2026",
+            "name": "NestJS",
+            "link": "https://nestjs.com/"
           }
         ],
         "role": {
@@ -364,6 +384,16 @@
             "id": "82593991",
             "name": "postgreSQL",
             "link": ""
+          },
+          {
+            "id": "skill_nodejs_tc2026",
+            "name": "Node.js",
+            "link": "https://nodejs.org/"
+          },
+          {
+            "id": "skill_nestjs_tc2026",
+            "name": "NestJS",
+            "link": "https://nestjs.com/"
           }
         ],
         "role": {
@@ -605,7 +635,7 @@
         "descriptionShort": "Gestion de la qualité des livrables et amélioration continue dans le cadre de la méthodologie SAFe."
       },
       {
-        "client": "leboncoin",
+        "client": "Leboncoin",
         "clientUrl": "https://www.leboncoin.fr",
         "location": "Paris",
         "startDate": "2021-08-01",
@@ -2351,6 +2381,16 @@
         "id": "skill_hexa_tc2026",
         "name": "Hexagonal architecture",
         "link": "https://alistair.cockburn.us/hexagonal-architecture/"
+      },
+      {
+        "id": "skill_nodejs_tc2026",
+        "name": "Node.js",
+        "link": "https://nodejs.org/"
+      },
+      {
+        "id": "skill_nestjs_tc2026",
+        "name": "NestJS",
+        "link": "https://nestjs.com/"
       }
     ],
     "allDomainsModels": [
@@ -2542,6 +2582,16 @@
             "id": "82518980",
             "name": "Matière Web",
             "link": "https://matiere-web.com/"
+          },
+          {
+            "id": "skill_nodejs_tc2026",
+            "name": "Node.js",
+            "link": "https://nodejs.org/"
+          },
+          {
+            "id": "skill_nestjs_tc2026",
+            "name": "NestJS",
+            "link": "https://nestjs.com/"
           }
         ],
         "role": {
@@ -2606,6 +2656,16 @@
             "id": "82593991",
             "name": "postgreSQL",
             "link": ""
+          },
+          {
+            "id": "skill_nodejs_tc2026",
+            "name": "Node.js",
+            "link": "https://nodejs.org/"
+          },
+          {
+            "id": "skill_nestjs_tc2026",
+            "name": "NestJS",
+            "link": "https://nestjs.com/"
           }
         ],
         "role": {
@@ -2847,7 +2907,7 @@
         "descriptionShort": "Management of the quality of deliverables and continuous improvement within the framework of the SAFe methodology."
       },
       {
-        "client": "leboncoin",
+        "client": "Leboncoin",
         "clientUrl": "https://www.leboncoin.fr",
         "location": "Paris",
         "startDate": "2021-08-01",

--- a/lib/short-offer-match.ts
+++ b/lib/short-offer-match.ts
@@ -82,5 +82,5 @@ export function computeShortUrlMatchData(
 
   const entries = buildMatchEntries(offer.requirements, jobs);
 
-  return { entries: entries.slice(0, SHORT_PROFILE_MATCH_MAX) };
+  return { entries };
 }


### PR DESCRIPTION
## Changes

- **Subtitle URL parameter support**: Added `subtitle`, `subtitle_fr`, and `subtitle_en` URL parameters to override the default CV subtitle (role) in both full and short CV modes
- **Job fit display enhancements**:
  - Removed requirement limit from URL parsing (`computeShortUrlMatchData`)
  - Implemented limit enforcement at component level (JobFitSection, ShortHeaderJobFitPills) using `SHORT_PROFILE_MATCH_MAX`
  - Short CV mode now displays only top `SHORT_PROFILE_MATCH_MAX` requirements
  - Added client count display in pills (e.g., "5 years · 3 clients")
- **CV data updates**: Added Node.js and NestJS skills to bundle.json, fixed "leboncoin" capitalization
- **Documentation**: Updated API guide with subtitle parameters and clarification on requirement ordering and display limits

## Files Modified

- `app/[lang]/header.tsx`: Accept `subtitleOverride` prop
- `app/[lang]/page.tsx`: Extract subtitle URL params and pass to Header
- `app/[lang]/short/page.tsx`: Extract subtitle URL params for short CV
- `app/api/llm-guide/route.ts`: Document new subtitle parameters and display behavior
- `components/JobFitSection.tsx`: Slice entries by `SHORT_PROFILE_MATCH_MAX` in compact mode, display client count
- `components/OfferTailoredShell.tsx`: Pass through `subtitleOverride`
- `components/ShortHeaderJobFitPills.tsx`: Apply requirement limit
- `lib/short-offer-match.ts`: Remove client-side slicing (moved to components)
- `data/cv/bundle.json`: Add Node.js and NestJS skills