### PR TITLE
docs(llm-guide): align with workAddress/commute params and spec JSON contract

### DIFF
--- a/app/api/llm-guide/route.ts
+++ b/app/api/llm-guide/route.ts
@@ -60,6 +60,10 @@ GET /{lang}?company=<nom>&requirement=<Label:kw1,kw2>[&...]
 | \`reqY\` | non | Annees d'experience affichees pour le i-eme requirement (remplace le calcul auto) |
 | \`contract\` | non | \`cdi\` ou \`freelance\` -- adapte textes profil/domaines, masque Malt en CDI |
 | \`job\` | non | Repetable. Slug d'une mission a mettre en avant (voir catalogue ci-dessous) |
+| \`workAddress\` | non | Adresse complete du lieu de travail. Active l'itineraire Google Maps gare -> bureau sur le pictogramme localisation. |
+| \`clientAddress\` | alias | Alias court de \`workAddress\`. |
+| \`commuteLabel\` | non | Libelle court affiche pres du lieu (ex. "~45 min"). Ignore sans \`workAddress\`. |
+| \`commuteMinutes\` | non | Minutes de trajet (numerique). Si fourni sans \`commuteLabel\`, genere "~N min". |
 | \`spec\` | non | JSON base64url (remplace les autres params d'offre si present) |
 | \`id\` | non | Identifiant interne optionnel |
 
@@ -187,14 +191,20 @@ Schema JSON decode :
 \`\`\`json
 {
   "company": "string (requis)",
-  "title": "string | { fr: string, en: string }",
+  "title": "string | { fr: string, en: string } (requis)",
   "requirements": [{ "label": "string", "keywords": ["string"], "experienceYearsOverride?": "number" }],
   "contract": "cdi | freelance (optionnel)",
-  "highlightedJobs": ["slug1", "slug2"] ,
+  "workAddress": "string (optionnel) -- itineraire Google Maps gare -> bureau",
+  "commuteLabel": "string (optionnel) -- libelle court affiche pres du lieu",
+  "commuteMinutes": "number (optionnel) -- si pas de commuteLabel, genere '~N min'",
+  "highlightedJobs": ["slug1", "slug2"],
   "id": "string (optionnel)",
   "url": "string (optionnel)"
 }
 \`\`\`
+
+> Aliases snake_case acceptes dans le spec JSON : \`experience_years_override\`,
+> \`highlighted_jobs\`, \`commute_minutes\`.
 
 ## Prompt rapide
 


### PR DESCRIPTION
## Summary

Audit du guide LLM (`/api/llm-guide`) face au code réel — 3 écarts corrigés :

- **Params URL contact/lieu non documentés** : `workAddress`, `clientAddress` (alias), `commuteLabel`, `commuteMinutes`. Parsés dans [`offer-contact-from-params.ts`](lib/offer-contact-from-params.ts) et utilisés sur la page CV full pour activer l'itinéraire Google Maps gare → bureau.
- **`title` n'était pas marqué requis dans le spec JSON** alors que [`dynamic-offer-spec.ts:92`](lib/dynamic-offer-spec.ts#L92) retourne `null` sans (contrairement aux query params qui fallback sur `company`). Un LLM qui omettait `title` dans le spec base64 obtenait un échec silencieux.
- **Champs spec JSON manquants** : `workAddress`, `commuteLabel`, `commuteMinutes` ajoutés au schéma. Note ajoutée pour les aliases snake_case acceptés (`experience_years_override`, `highlighted_jobs`, `commute_minutes`).

Aucun changement de comportement — uniquement de la doc générée par l'endpoint.

## Test plan

- [x] `npm test` (prettier + lint) — vert
- [x] `npm run test:unit` — 153 tests verts
- [x] `npx tsc --noEmit` — pas d'erreur de typage
- [ ] Vérifier visuellement le rendu du guide sur https://www.elzinko.fr/api/llm-guide après merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)