### PR TITLE
fix(dev): block /dev/ pages on Vercel deployments

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -24,6 +24,15 @@ export function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
   const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
 
+  if (process.env.VERCEL === '1') {
+    const devPattern = /^\/(?:fr|en)\/dev\//;
+    if (devPattern.test(pathname)) {
+      return NextResponse.rewrite(new URL('/not-found', request.url), {
+        status: 404,
+      });
+    }
+  }
+
   // Case where the user is accessing the root path
   if (pathname === '' || pathname === '/') {
     const locale = getLocale(request);


### PR DESCRIPTION
## Summary

- The `/[lang]/dev/renders` and `/[lang]/dev/components` pages are local development tools (Playwright snapshot viewer, component showcase). They were broken on production (`/api/renders/file` returns 403, snapshots show as broken images).
- Block these routes in `middleware.ts` via `process.env.VERCEL === '1'` so they 404 on every Vercel deployment (production + preview), while remaining fully accessible with `next dev` / `next start` locally.
- Also addresses the `/en/components` 404 — it pointed at a non-existent route; the dev tool stays at `/en/dev/components` locally only, which matches the original intent.

## Why this approach

Initially considered moving the snapshot PNGs/PDFs into `public/renders/` to make them publicly servable, but these are dev-only tools, exposing them adds bytes to every Vercel deployment for no end-user value, and Vercel storage limits make committing large binaries risky long-term.

A middleware guard keyed on `VERCEL=1` (Vercel's auto-set system env var, no dashboard config needed) is the smallest possible change.

## Test plan

- [ ] `pnpm dev` locally → `/en/dev/renders` and `/en/dev/components` still work
- [ ] Deploy preview on Vercel → both routes return 404
- [ ] Production deploy → `/en/dev/renders` and `/en/dev/components` return 404
- [ ] Normal routes (`/en`, `/fr/short`, `/api/profile`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)