### PR TITLE
feat(cv): make education-level pill opt-in via `?edu=1`

### DIFF
--- a/app/[lang]/dev/components/page.tsx
+++ b/app/[lang]/dev/components/page.tsx
@@ -242,6 +242,7 @@ export default async function DevComponentsPage({
               lang={lang}
               educationLevel={educationLevel}
               variant="full"
+              showEducationLevel
             />
           </Suspense>
         </div>
@@ -262,6 +263,7 @@ export default async function DevComponentsPage({
                 lang={lang}
                 educationLevel={educationLevel}
                 variant="compact"
+                showEducationLevel
               />
             </Suspense>
           </Narrow>

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -66,6 +66,9 @@ export default async function Page({
       ? sp.get('subtitle_fr') || sp.get('subtitle')
       : sp.get('subtitle_en') || sp.get('subtitle')
     )?.trim() || undefined;
+  const eduRaw = sp.get('edu')?.trim();
+  const showEducationLevel =
+    offer?.showEducation === true || eduRaw === '1' || eduRaw === 'true';
   const contact = data.contact as
     | { email?: string; phone?: string; location?: string }
     | undefined;
@@ -84,6 +87,7 @@ export default async function Page({
       hideMalt={contract === 'cdi'}
       contract={contract}
       subtitleOverride={subtitleOverride}
+      showEducationLevel={showEducationLevel}
     />
   );
 }

--- a/app/[lang]/short/page.tsx
+++ b/app/[lang]/short/page.tsx
@@ -17,6 +17,8 @@ import {
   resolveAboutText,
   resolveDomainDescription,
 } from '@/lib/cv-contract-text';
+import { resolveOfferFromUrlParams } from '@/lib/query-offer-params';
+import { getMatchCatalog } from '@/lib/match-catalog-server';
 import type { ContractType } from '@/data/offers/types';
 import type { Metadata } from 'next';
 
@@ -63,6 +65,11 @@ export default async function ShortPage({
       ? sp.get('subtitle_fr') || sp.get('subtitle')
       : sp.get('subtitle_en') || sp.get('subtitle')
     )?.trim() || undefined;
+
+  const offer = resolveOfferFromUrlParams(sp, getMatchCatalog());
+  const eduRaw = sp.get('edu')?.trim();
+  const showEducationLevel =
+    offer?.showEducation === true || eduRaw === '1' || eduRaw === 'true';
 
   // Missions mises en avant par le LLM (param `job`, répétable)
   const jobParam = searchParams?.job;
@@ -157,6 +164,7 @@ export default async function ShortPage({
           data={compactData}
           lang={lang as 'fr' | 'en'}
           highlightedJobSlugs={highlightedJobSlugs}
+          showEducationLevel={showEducationLevel}
         />
       </ShortPageWrapper>
     </>

--- a/app/api/llm-guide/route.ts
+++ b/app/api/llm-guide/route.ts
@@ -99,6 +99,7 @@ GET /{lang}?company=<nom>&requirement=<Label:kw1,kw2>[&...]
 | \`requirement\` | **oui** (1+) | Repetable. Format : \`Label:keyword1,keyword2\` |
 | \`req\` | alias | Alias court pour \`requirement\` |
 | \`reqY\` | non | Annees d'experience affichees pour le i-eme requirement (remplace le calcul auto) |
+| \`edu\` | non | \`1\` ou \`true\` → affiche la pastille de niveau de formation (« Bac+5 » FR / « Master's-level » EN). Masquee par defaut. |
 | \`contract\` | non | \`cdi\` ou \`freelance\` -- adapte textes profil/domaines, masque Malt en CDI |
 | \`job\` | non | Repetable. Slug d'une mission a mettre en avant (voir liste ci-dessous) |
 | \`workAddress\` | non | Adresse complete du lieu de travail. Active l'itineraire Google Maps gare -> bureau sur le pictogramme localisation. |
@@ -160,7 +161,7 @@ Exemple : \`subtitle_fr=Chef+de+Projet+Java+Full+Stack&subtitle_en=Java+Full+Sta
 
 ## Vignettes adequation poste
 
-- 1 vignette education (toujours affichee) : "Bac+5" (FR) / "Master's-level" (EN).
+- 1 vignette education **optionnelle** (opt-in via \`edu=1\` ou \`showEducation: true\` dans le spec JSON) : "Bac+5" (FR) / "Master's-level" (EN).
 - Max **${SHORT_PROFILE_MATCH_MAX}** vignettes technologiques en mode short.
 - Pas de limite en mode full (CV complet).
 - En mode short, chaque vignette indique le nombre de clients (missions).
@@ -233,13 +234,14 @@ Schema JSON decode :
   "commuteLabel": "string (optionnel) -- libelle court affiche pres du lieu",
   "commuteMinutes": "number (optionnel) -- si pas de commuteLabel, genere '~N min'",
   "highlightedJobs": ["slug1", "slug2"],
+  "showEducation": "boolean (optionnel) -- affiche la pastille « Bac+5 / Master's-level »",
   "id": "string (optionnel)",
   "url": "string (optionnel)"
 }
 \`\`\`
 
 > Aliases snake_case acceptes dans le spec JSON : \`experience_years_override\`,
-> \`highlighted_jobs\`, \`commute_minutes\`.
+> \`highlighted_jobs\`, \`commute_minutes\`, \`show_education\`.
 
 ## Prompt rapide (generation d'URL de CV personnalise)
 

--- a/components/CompactCvLayout.tsx
+++ b/components/CompactCvLayout.tsx
@@ -76,6 +76,8 @@ interface CompactCvLayoutProps {
   lang: 'fr' | 'en';
   /** Slugs de missions à mettre en avant (ex. "jpb-systeme"). Vide = comportement chrono par défaut. */
   highlightedJobSlugs?: string[];
+  /** Affiche la pastille « Bac+5 / Master's-level » dans la section adéquation. Opt-in via `?edu=1`. */
+  showEducationLevel?: boolean;
   /** Emplacement réservé pour extensions — non utilisé par défaut. */
   children?: React.ReactNode;
 }
@@ -84,6 +86,7 @@ export default function CompactCvLayout({
   data,
   lang,
   highlightedJobSlugs,
+  showEducationLevel = false,
   children,
 }: CompactCvLayoutProps) {
   // Fallback labels if bundle.json titles are empty
@@ -170,6 +173,7 @@ export default function CompactCvLayout({
             lang={lang}
             educationLevel={data.educationLevel}
             variant="compact"
+            showEducationLevel={showEducationLevel}
           />
         </Suspense>
         <section>
@@ -202,6 +206,7 @@ export default function CompactCvLayout({
                 lang={lang}
                 educationLevel={data.educationLevel}
                 variant="compact"
+                showEducationLevel={showEducationLevel}
               />
             </Suspense>
           </div>

--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -21,6 +21,8 @@ interface JobFitSectionProps {
   educationLevel: EducationLevelContent;
   /** 'full' = liste verticale avec detail (CV complet), 'compact' = pastilles inline (CV court). */
   variant?: 'full' | 'compact';
+  /** Affiche la pastille niveau de formation (« Bac+5 / Master's-level »). Opt-in via `?edu=1`. */
+  showEducationLevel?: boolean;
 }
 
 /**
@@ -32,6 +34,7 @@ export default function JobFitSection({
   lang,
   educationLevel,
   variant = 'full',
+  showEducationLevel = false,
 }: JobFitSectionProps) {
   const offerData = useShortOfferMatchData(lang);
 
@@ -54,10 +57,11 @@ export default function JobFitSection({
           {sectionTitle}
         </h2>
         <div className="cv-section-body-gap flex flex-wrap items-center gap-1.5 print:gap-1">
-          {/* Education level pill */}
-          <Pill color="match" compact>
-            {educationLevel.levelPrimary}
-          </Pill>
+          {showEducationLevel && (
+            <Pill color="match" compact>
+              {educationLevel.levelPrimary}
+            </Pill>
+          )}
 
           {/* Tech pills */}
           {entries.map((entry, index) => {
@@ -105,13 +109,14 @@ export default function JobFitSection({
       </div>
 
       <ul className="mt-3 space-y-2.5 print:mt-2 print:space-y-1.5 md:mt-4 md:space-y-3">
-        {/* Education level row */}
-        <li className="flex flex-wrap items-baseline gap-x-2 gap-y-1 print:gap-x-1.5">
-          <Pill color="match">{educationLevel.levelPrimary}</Pill>
-          <span className="text-sm text-cv-body-muted print:text-[10px] md:text-base">
-            {educationLevel.effectiveLevelDetail}
-          </span>
-        </li>
+        {showEducationLevel && (
+          <li className="flex flex-wrap items-baseline gap-x-2 gap-y-1 print:gap-x-1.5">
+            <Pill color="match">{educationLevel.levelPrimary}</Pill>
+            <span className="text-sm text-cv-body-muted print:text-[10px] md:text-base">
+              {educationLevel.effectiveLevelDetail}
+            </span>
+          </li>
+        )}
 
         {/* Tech entry rows */}
         {entries.map((entry, index) => {

--- a/components/OfferTailoredShell.tsx
+++ b/components/OfferTailoredShell.tsx
@@ -32,6 +32,7 @@ export default function OfferTailoredShell({
   hideMalt,
   contract,
   subtitleOverride,
+  showEducationLevel = false,
 }: {
   lang: Locale;
   educationLevel: EducationLevelContent;
@@ -51,6 +52,8 @@ export default function OfferTailoredShell({
   contract?: ContractType;
   /** Surcharge du sous-titre (rôle) dans l'en-tête. */
   subtitleOverride?: string;
+  /** Affiche la pastille « Bac+5 / Master's-level » dans la section adéquation. */
+  showEducationLevel?: boolean;
 }) {
   const resolvedContact: ContactLocationOverlay = contactLocation ?? {
     mapsHref: buildContactLocationHref(),
@@ -91,6 +94,7 @@ export default function OfferTailoredShell({
                 lang={lang}
                 educationLevel={educationLevel}
                 variant="full"
+                showEducationLevel={showEducationLevel}
               />
             </Suspense>
             {/* Coordonnées : après Adéquation poste, même placement que le CV court. */}

--- a/data/offers/types.ts
+++ b/data/offers/types.ts
@@ -27,4 +27,6 @@ export interface JobOffer {
   commuteLabel?: string;
   /** Slugs de missions à mettre en avant (CV court). Valeurs = slug client sans préfixe "mission-". */
   highlightedJobs?: string[];
+  /** Affiche la pastille « Bac+5 » / « Master's-level » en tête de la section adéquation. */
+  showEducation?: boolean;
 }

--- a/lib/dynamic-offer-spec.ts
+++ b/lib/dynamic-offer-spec.ts
@@ -129,6 +129,8 @@ export function parseJobOfferFromUnknown(
         .slice(0, 24)
     : undefined;
 
+  const showEducation = (o.showEducation ?? o.show_education) === true;
+
   return enrichJobOfferRequirements(
     {
       id,
@@ -140,6 +142,7 @@ export function parseJobOfferFromUnknown(
       ...(workAddress ? { workAddress } : {}),
       ...(commuteLabel ? { commuteLabel } : {}),
       ...(highlightedJobs?.length ? { highlightedJobs } : {}),
+      ...(showEducation ? { showEducation: true } : {}),
     },
     catalog,
   );

--- a/lib/query-offer-params.ts
+++ b/lib/query-offer-params.ts
@@ -127,6 +127,9 @@ export function buildOfferFromQueryParams(
   const highlightedJobs =
     jobParams.length > 0 ? jobParams.slice(0, 24) : undefined;
 
+  const eduRaw = sp.get('edu')?.trim();
+  const showEducation = eduRaw === '1' || eduRaw === 'true';
+
   return enrichJobOfferRequirements(
     {
       id,
@@ -135,6 +138,7 @@ export function buildOfferFromQueryParams(
       requirements,
       contract,
       ...(highlightedJobs ? { highlightedJobs } : {}),
+      ...(showEducation ? { showEducation: true } : {}),
     },
     catalog,
   );


### PR DESCRIPTION
## Summary

- La pastille « Bac+5 » / « Master's-level » de la section *Adéquation poste* était toujours rendue (en première ligne), même sur des URLs comme `?company=iad&requirement=Node.js…` qui ne la demandaient pas explicitement. Comme ce libellé est statique (lu depuis `data/cv/locales/{fr,en}.json`) et non calculé à partir des missions comme les autres entrées, il doit être opt-in.
- Nouveau paramètre URL `edu` (truthy : `1` ou `true`) qui active l'affichage. Masqué par défaut sinon.
- Nouveau champ `showEducation` (booléen) dans le contrat `?spec=` JSON, avec l'alias snake_case `show_education` pour rester cohérent avec les autres champs (`experience_years_override`, `highlighted_jobs`, `commute_minutes`).
- Documentation `/api/llm-guide` mise à jour (tableau des params, section *Vignettes adequation poste*, schéma JSON du spec, note des alias snake_case).
- La showcase `/{lang}/dev/components` force `showEducationLevel={true}` pour continuer d'afficher la pastille dans ses deux variantes.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:unit` — 149/149 passing
- [x] `npm test` (prettier + lint) — clean
- [x] `curl /fr?company=iad&requirement=Node.js:nodejs` → aucune pastille « Bac+5 » dans le HTML rendu
- [x] `curl /fr?company=iad&requirement=Node.js:nodejs&edu=1` → pastille « Bac+5 » + détail « Valorisé par 20 ans… » visibles
- [x] `curl /api/llm-guide` → ligne `edu`, schéma `showEducation`, alias `show_education` présents
- [x] Vérifié sur preview Vercel : `/en?…&edu=1` rend « Master's-level » + « Backed by 20 years of professional experience »
- [x] Vérifié sur preview Vercel : `/fr/short?company=…&edu=1` → variant compact rend la pastille `Bac+5`
- [x] Vérifié sur preview Vercel : `/fr?spec=<base64 avec showEducation:true>` → pastille affichée ; spec sans `showEducation` ne la rend pas
- [x] `/fr/dev/components` — vérifié localement (les pages `/dev/` sont volontairement bloquées sur Vercel via commit `ea6ef7a`, donc 404 sur le preview ; les deux usages de `<JobFitSection>` y reçoivent `showEducationLevel` en dur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)