### PR TITLE
feat(cv): add teaching mode (?mode=teaching) + motivation letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npm run build
 - **Paramètres lisibles** : `/{lang}?company=…&requirement=Libellé:mots&contract=cdi`
 - **JSON compact base64** : `/{lang}?spec=…`
 - **Type de contrat** : `?contract=cdi` adapte les textes profil/domaines pour un poste permanent ; `freelance` par défaut.
+- **Mode enseignement** : `?mode=teaching` bascule sur la variante CV enseignement (profil/domaines reformulés, missions d'enseignement et proposition de module Product Builder visibles, lien Malt masqué). Voir [`letters/`](letters/) pour les lettres associées.
 - **Guide LLM dynamique** : `GET /api/llm-guide` — markdown auto-généré, point d'entrée recommandé pour les agents LLM. Liste tous les endpoints publics (`/api/profile`, `/api/openapi.yaml`, `/{lang}`), le catalogue de technos complet et des exemples d'URLs.
 
 Plafonds (longueurs, nombre d’exigences) : `lib/dynamic-offer-spec.ts`, `lib/query-offer-params.ts`. URLs limitées à ~2k caractères par le navigateur ; au-delà, préférer `spec` base64.

--- a/app/[lang]/about.tsx
+++ b/app/[lang]/about.tsx
@@ -1,5 +1,5 @@
 import { getCvData } from '@/lib/cv-data';
-import { resolveAboutText } from '@/lib/cv-contract-text';
+import { resolveAboutText, type CvMode } from '@/lib/cv-contract-text';
 import type { ContractType } from '@/data/offers/types';
 import type { EducationLevelContent } from '@/lib/education-level-content';
 import { Locale } from 'i18n-config';
@@ -9,10 +9,12 @@ export default async function About({
   locale,
   educationLevel,
   contract,
+  mode,
 }: {
   locale: Locale;
   educationLevel: EducationLevelContent;
   contract?: ContractType;
+  mode?: CvMode;
 }) {
   const data: any = await getCvData(locale);
 
@@ -27,7 +29,7 @@ export default async function About({
         </h2>
       </div>
       <p className="mt-4 text-cv-body-muted">
-        {resolveAboutText(data?.about, contract)}
+        {resolveAboutText(data?.about, contract, mode)}
       </p>
     </section>
   );

--- a/app/[lang]/domains.tsx
+++ b/app/[lang]/domains.tsx
@@ -1,6 +1,6 @@
 import Domain from '@/components/Domain';
 import { getCvData } from '@/lib/cv-data';
-import { resolveDomainDescription } from '@/lib/cv-contract-text';
+import { resolveDomainDescription, type CvMode } from '@/lib/cv-contract-text';
 import type { ContractType } from '@/data/offers/types';
 import { Locale } from 'i18n-config';
 import React from 'react';
@@ -8,9 +8,11 @@ import React from 'react';
 export default async function domains({
   locale,
   contract,
+  mode,
 }: {
   locale: Locale;
   contract?: ContractType;
+  mode?: CvMode;
 }) {
   const data: any = await getCvData(locale);
   return (
@@ -24,7 +26,7 @@ export default async function domains({
             key={domain.id}
             domain={{
               ...domain,
-              description: resolveDomainDescription(domain, contract),
+              description: resolveDomainDescription(domain, contract, mode),
             }}
           />
         ))}

--- a/app/[lang]/jobs.tsx
+++ b/app/[lang]/jobs.tsx
@@ -1,6 +1,7 @@
 import Job from '@/components/Job';
 import ExperienceClosingBlock from '@/components/ExperienceClosingBlock';
 import { getCvData } from '@/lib/cv-data';
+import type { CvMode } from '@/lib/cv-contract-text';
 import {
   formatRemainingClientsRecapForFullCv,
   getExperienceClosingLabels,
@@ -8,11 +9,21 @@ import {
 import { Locale } from 'i18n-config';
 import React from 'react';
 
-export default async function jobs({ locale }: { locale: Locale }) {
+export default async function jobs({
+  locale,
+  mode,
+}: {
+  locale: Locale;
+  mode?: CvMode;
+}) {
   const data: any = await getCvData(locale);
   const jobsList = data?.allJobsModels || [];
   const visibleJobs = jobsList.filter(
-    (j: { display?: boolean }) => j.display !== false,
+    (j: { display?: boolean; displayMode?: string }) => {
+      if (j.display === false) return false;
+      if (j.displayMode && j.displayMode !== mode) return false;
+      return true;
+    },
   );
   const closing = getExperienceClosingLabels(locale);
   const recapLine = formatRemainingClientsRecapForFullCv(visibleJobs, locale);

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -10,6 +10,7 @@ import { offerPriorityTokensAndContact } from '@/lib/offer-page-data';
 import { resolveOfferFromUrlParams } from '@/lib/query-offer-params';
 import { recordToURLSearchParams } from '@/lib/search-params-to-url';
 import type { ContractType } from '@/data/offers/types';
+import type { CvMode } from '@/lib/cv-contract-text';
 
 export const dynamic = 'force-dynamic';
 
@@ -57,6 +58,10 @@ export default async function Page({
     contractParam === 'cdi' || contractParam === 'freelance'
       ? contractParam
       : undefined;
+  const modeParam =
+    typeof searchParams?.mode === 'string' ? searchParams.mode : undefined;
+  const mode: CvMode | undefined =
+    modeParam === 'teaching' ? 'teaching' : undefined;
   const { priorityTokens, contactLocation } = offerPriorityTokensAndContact(
     offer,
     sp,
@@ -84,8 +89,9 @@ export default async function Page({
       }}
       frameworkDisplayPriorityTokens={priorityTokens}
       contactLocation={contactLocation}
-      hideMalt={contract === 'cdi'}
+      hideMalt={contract === 'cdi' || mode === 'teaching'}
       contract={contract}
+      mode={mode}
       subtitleOverride={subtitleOverride}
       showEducationLevel={showEducationLevel}
     />

--- a/app/[lang]/projects.tsx
+++ b/app/[lang]/projects.tsx
@@ -1,5 +1,6 @@
 import Project from '@/components/Project';
 import { getCvData } from '@/lib/cv-data';
+import type { CvMode } from '@/lib/cv-contract-text';
 import {
   byEndThenStart,
   sortChronologicalDesc,
@@ -11,14 +12,20 @@ export default async function projects({
   locale,
   sectionId = 'projects',
   className = '',
+  mode,
 }: {
   locale: Locale;
   sectionId?: string | false;
   className?: string;
+  mode?: CvMode;
 }) {
   const data: any = await getCvData(locale);
   const visibleProjects = (data?.allProjectsModels || []).filter(
-    (p: { display?: boolean }) => p.display !== false,
+    (p: { display?: boolean; displayMode?: string }) => {
+      if (p.display === false) return false;
+      if (p.displayMode && p.displayMode !== mode) return false;
+      return true;
+    },
   );
   const projectsOrdered = sortChronologicalDesc(
     visibleProjects,

--- a/app/[lang]/short/page.tsx
+++ b/app/[lang]/short/page.tsx
@@ -108,7 +108,11 @@ export default async function ShortPage({
       competencies: d.competencies || [],
     })),
     jobs: (data?.allJobsModels || [])
-      .filter((j: { display?: boolean }) => j.display !== false)
+      .filter((j: { display?: boolean; displayMode?: string }) => {
+        if (j.display === false) return false;
+        if (j.displayMode) return false;
+        return true;
+      })
       .map((j: any) => {
         const dates = formatDates(j.startDate, j.endDate);
         const [start, end] = dates ? dates.split(' - ') : ['', ''];
@@ -140,7 +144,11 @@ export default async function ShortPage({
     projectsTitle: data?.projectsTitle?.title ?? 'Projects',
     projects: sortChronologicalDesc(
       (data?.allProjectsModels || []).filter(
-        (p: { display?: boolean }) => p.display !== false,
+        (p: { display?: boolean; displayMode?: string }) => {
+          if (p.display === false) return false;
+          if (p.displayMode) return false;
+          return true;
+        },
       ),
       byEndThenStart,
     ),

--- a/components/OfferTailoredShell.tsx
+++ b/components/OfferTailoredShell.tsx
@@ -16,6 +16,7 @@ import type { ContactLocationOverlay } from '@/lib/offer-contact-from-params';
 import type { EducationLevelContent } from '@/lib/education-level-content';
 import ContactDisplay from '@/components/ContactDisplay';
 import type { ContractType } from '@/data/offers/types';
+import type { CvMode } from '@/lib/cv-contract-text';
 import type { Locale } from 'i18n-config';
 /**
  * Mise en page commune des pages CV « sur mesure » (custom / match).
@@ -31,6 +32,7 @@ export default function OfferTailoredShell({
   contactLocation,
   hideMalt,
   contract,
+  mode,
   subtitleOverride,
   showEducationLevel = false,
 }: {
@@ -50,6 +52,8 @@ export default function OfferTailoredShell({
   hideMalt?: boolean;
   /** Type de contrat : adapte les textes Profil et Domaines. */
   contract?: ContractType;
+  /** Mode CV (`teaching` pour la variante enseignement). Affiche les missions/projets `displayMode=mode` et utilise les textes `*Teaching`. */
+  mode?: CvMode;
   /** Surcharge du sous-titre (rôle) dans l'en-tête. */
   subtitleOverride?: string;
   /** Affiche la pastille « Bac+5 / Master's-level » dans la section adéquation. */
@@ -84,9 +88,10 @@ export default function OfferTailoredShell({
                 locale={lang}
                 educationLevel={educationLevel}
                 contract={contract}
+                mode={mode}
               />
               {/* @ts-expect-error Server Component */}
-              <Domains locale={lang} contract={contract} />
+              <Domains locale={lang} contract={contract} mode={mode} />
             </div>
             {/* Adéquation poste : niveau de formation + compétences techniques */}
             <Suspense fallback={null}>
@@ -121,11 +126,11 @@ export default function OfferTailoredShell({
               </section>
             )}
             {/* @ts-expect-error Server Component */}
-            <Jobs locale={lang} />
+            <Jobs locale={lang} mode={mode} />
             {/* @ts-expect-error Server Component */}
             <Studies locale={lang} />
             {/* @ts-expect-error Server Component */}
-            <Projects locale={lang} />
+            <Projects locale={lang} mode={mode} />
             {/* @ts-expect-error Server Component */}
             <Learnings locale={lang} />
             {/* @ts-expect-error Server Component */}

--- a/data/cv/experience.json
+++ b/data/cv/experience.json
@@ -2,6 +2,33 @@
   "schemaVersion": 1,
   "jobs": [
     {
+      "slug": "iut-vacations",
+      "client": "IUT Sénart-Fontainebleau",
+      "startDate": "2015-09-01",
+      "endDate": "2017-06-30",
+      "roleId": "role-teaching-vacataire",
+      "clientUrl": "https://iutsf.u-pec.fr/",
+      "frameworks": [
+        "91050006",
+        "91050007",
+        "82456019",
+        "82456040",
+        "82456042",
+        "82609066",
+        "82627943"
+      ],
+      "displayMode": "teaching"
+    },
+    {
+      "slug": "cours-particuliers-2002-2006",
+      "client": "Cours particuliers — Maths & Physique",
+      "startDate": "2002-09-01",
+      "endDate": "2006-06-30",
+      "roleId": "role-teaching-tuteur",
+      "frameworks": [],
+      "displayMode": "teaching"
+    },
+    {
       "slug": "solopreneur",
       "client": "Solopreneur",
       "startDate": "2023-01-01",
@@ -493,6 +520,26 @@
     }
   ],
   "projects": [
+    {
+      "id": "module-product-builder",
+      "name": "Module Product Builder (proposition IUT)",
+      "startDate": "2026-09-01",
+      "endDate": null,
+      "frameworks": [
+        "81826170",
+        "82456019",
+        "82456008",
+        "cnZskAq6SqSbkXAmAB0KIQ"
+      ],
+      "bullets": [],
+      "tags": [
+        {
+          "id": "tag-module-product-builder",
+          "name": "proposition"
+        }
+      ],
+      "displayMode": "teaching"
+    },
     {
       "id": "cvproj-shopify-assistant",
       "name": "shopify-plugin-product-assistant",

--- a/data/cv/locales/en.json
+++ b/data/cv/locales/en.json
@@ -55,6 +55,50 @@
     }
   },
   "jobs": {
+    "iut-vacations": {
+      "location": "Lieusaint (77) — Sénart campus",
+      "roleName": "Adjunct lecturer — 1st year",
+      "description": "",
+      "descriptionShort": "Two consecutive years (2015-2016 and 2016-2017) teaching first-year IUT students on the web module, at the Sénart campus of IUT Sénart-Fontainebleau (UPEC).",
+      "bullets": [
+        {
+          "id": "job_iut_vacations_en_b_modules",
+          "text": "Topics taught: HTML / CSS, JavaScript, DOM manipulation, web development fundamentals."
+        },
+        {
+          "id": "job_iut_vacations_en_b_outils",
+          "text": "Developer tooling: editor, terminal, Git / GitLab, peer code reviews, team conventions."
+        },
+        {
+          "id": "job_iut_vacations_en_b_cicd",
+          "text": "Continuous integration & delivery: GitLab CI pipelines, quality (lint, tests), automated deployment."
+        },
+        {
+          "id": "job_iut_vacations_en_b_pedagogie",
+          "text": "Hands-on approach: red-thread projects, individual mentoring, deliverable-based grading."
+        }
+      ]
+    },
+    "cours-particuliers-2002-2006": {
+      "location": "Fontainebleau (77) — home",
+      "roleName": "Private tutor",
+      "description": "",
+      "descriptionShort": "Private tutoring in mathematics and physics for middle-school and high-school students, alongside my own studies.",
+      "bullets": [
+        {
+          "id": "job_cours_part_en_b_niveaux",
+          "text": "Levels: 6th grade through senior year, year-long follow-up."
+        },
+        {
+          "id": "job_cours_part_en_b_matieres",
+          "text": "Subjects: mathematics (algebra, geometry, calculus) and physics (mechanics, electricity)."
+        },
+        {
+          "id": "job_cours_part_en_b_approche",
+          "text": "Approach: gap diagnosis, reformulation, progressive exercises, exam preparation."
+        }
+      ]
+    },
     "solopreneur": {
       "location": "@home · home office",
       "roleName": "Solopreneur · side projects",
@@ -401,6 +445,10 @@
     }
   },
   "projects": {
+    "module-product-builder": {
+      "title": "Product Builder module — IUT proposal",
+      "description": "A first- or second-year module taking students through a full product cycle: ideation, framing, UI design, MVP development, production deployment and operations. The module embeds modern AI tools (prompt engineering, LLM agents, RAG, MCP) as realistic accelerators of the developer craft. Goal: graduates capable of shipping a digital product end to end, solo or in a team, with the quality and industrialization reflexes expected in industry."
+    },
     "82518980": {
       "description": "Co-founder and director of the web agency \"Matière Web\""
     },

--- a/data/cv/locales/fr.json
+++ b/data/cv/locales/fr.json
@@ -12,7 +12,8 @@
   "about": {
     "title": "Profile",
     "text": "Je suis un consultant informatique fullstack agile passionné par les technologies open source frontend et backend. J'aime développer des logiciels à l'aide de solutions cloud, le tout dans la lignée du mouvement Devops.",
-    "textCdi": "Ingénieur fullstack agile avec 20 ans d'expérience, je conçois des applications robustes en environnement cloud avec une culture DevOps et craftsmanship, sur des stacks open source frontend et backend."
+    "textCdi": "Ingénieur fullstack agile avec 20 ans d'expérience, je conçois des applications robustes en environnement cloud avec une culture DevOps et craftsmanship, sur des stacks open source frontend et backend.",
+    "textTeaching": "Ingénieur informatique formé à l'IUT (DUT Informatique puis Licence Professionnelle), j'ai construit 20 ans d'expérience industrielle — du grand groupe (BlaBlaCar, SNCF, Thales, leboncoin) à la startup et au solopreneuriat, sur tout le cycle produit (idée, MVP, mise en production, run). Je souhaite aujourd'hui me consacrer à l'enseignement et m'ancrer durablement près de chez moi (Thomery, 77) : transmettre, accompagner les étudiants vers l'autonomie, et ramener dans la salle de cours la réalité du métier de développeur et de créateur de produits numériques."
   },
   "ui": {
     "skillsTitle": "Compétences",
@@ -43,18 +44,65 @@
   "domains": {
     "78726111": {
       "description": "J'aime développer des composants réutilisables dans un environnement clusterisé en utilisant des concepts tels que microservices, robustesse, observabilité, clean code.",
-      "descriptionCdi": "Je conçois des composants réutilisables dans un environnement clusterisé avec les principes microservices, robustesse, observabilité et clean code."
+      "descriptionCdi": "Je conçois des composants réutilisables dans un environnement clusterisé avec les principes microservices, robustesse, observabilité et clean code.",
+      "descriptionTeaching": "Je transmets les fondamentaux du génie logiciel — architecture, robustesse, lisibilité, tests, observabilité — à partir de cas industriels concrets, pour que les étudiants comprennent pourquoi ces principes existent avant d'apprendre comment les appliquer."
     },
     "78726113": {
       "description": "Je sais mettre à profit mes multiples expériences d'agilité au service d'une équipe afin d'aboutir à un produit proche du besoin avec une philosophie software craftsmanship.",
-      "descriptionCdi": "Fort de multiples expériences agiles, j'accompagne les équipes vers un produit au plus proche du besoin, dans une démarche software craftsmanship et d'amélioration continue."
+      "descriptionCdi": "Fort de multiples expériences agiles, j'accompagne les équipes vers un produit au plus proche du besoin, dans une démarche software craftsmanship et d'amélioration continue.",
+      "descriptionTeaching": "J'enseigne l'agilité et le software craftsmanship par la pratique : un projet d'équipe mené sur la durée, sprints, revues de code, rétrospectives — pour donner aux étudiants l'expérience d'un cycle produit réel, pas seulement la théorie."
     },
     "78855347": {
       "description": "Je travaille avec les opérationnels en privilégiant le déploiement continu : livrer vite de la valeur concrète tout en réduisant les frictions entre métiers et production.",
-      "descriptionCdi": "Je pratique le déploiement continu au quotidien pour livrer rapidement de la valeur concrète, en réduisant les frictions entre développement et production."
+      "descriptionCdi": "Je pratique le déploiement continu au quotidien pour livrer rapidement de la valeur concrète, en réduisant les frictions entre développement et production.",
+      "descriptionTeaching": "J'initie aux pipelines CI/CD, à l'industrialisation et au déploiement continu avec les outils du marché (Git, GitLab CI, Docker, cloud), pour que les étudiants quittent l'IUT avec le réflexe « livré, c'est mieux que parfait »."
     }
   },
   "jobs": {
+    "iut-vacations": {
+      "location": "Lieusaint (77) — site de Sénart",
+      "roleName": "Enseignant vacataire — 1ère année",
+      "description": "",
+      "descriptionShort": "Deux années consécutives de vacations en première année (2015-2016 puis 2016-2017) sur le module web, au site de Sénart de l'IUT Sénart-Fontainebleau (UPEC).",
+      "bullets": [
+        {
+          "id": "job_iut_vacations_fr_b_modules",
+          "text": "Modules enseignés : HTML / CSS, JavaScript, manipulation du DOM, fondamentaux du développement web."
+        },
+        {
+          "id": "job_iut_vacations_fr_b_outils",
+          "text": "Outillage du dev : éditeur, terminal, Git / GitLab, revues de code par les pairs, conventions d'équipe."
+        },
+        {
+          "id": "job_iut_vacations_fr_b_cicd",
+          "text": "Intégration et déploiement continus : pipelines GitLab CI, qualité (lint, tests), mise en ligne automatisée."
+        },
+        {
+          "id": "job_iut_vacations_fr_b_pedagogie",
+          "text": "Approche pratique : projets fil rouge, encadrement individualisé, évaluation par livrables."
+        }
+      ]
+    },
+    "cours-particuliers-2002-2006": {
+      "location": "Fontainebleau (77) — domicile",
+      "roleName": "Tuteur — cours particuliers",
+      "description": "",
+      "descriptionShort": "Cours particuliers de mathématiques et physique à des élèves de collège et lycée, en parallèle de mes études (prépa PTSI/PSI, DUT Informatique, Licence Pro).",
+      "bullets": [
+        {
+          "id": "job_cours_part_fr_b_niveaux",
+          "text": "Niveaux : 6ᵉ à terminale S, suivi régulier sur l'année scolaire."
+        },
+        {
+          "id": "job_cours_part_fr_b_matieres",
+          "text": "Matières : mathématiques (algèbre, géométrie, analyse) et physique (mécanique, électricité)."
+        },
+        {
+          "id": "job_cours_part_fr_b_approche",
+          "text": "Approche : diagnostic des lacunes, reformulation, exercices progressifs, préparation aux contrôles et au bac."
+        }
+      ]
+    },
     "solopreneur": {
       "location": "@home · maison",
       "roleName": "Solopreneur · projets personnels",
@@ -401,6 +449,10 @@
     }
   },
   "projects": {
+    "module-product-builder": {
+      "title": "Module Product Builder — proposition IUT",
+      "description": "Module de 1ère ou 2ᵉ année qui fait vivre aux étudiants un cycle produit complet : idéation, cadrage, design d'interface, développement d'un MVP, mise en production et run. Le module intègre les outils IA modernes (prompt engineering, agents LLM, RAG, MCP) comme accélérateurs réalistes du métier de développeur. Objectif : former des étudiants capables de livrer un produit numérique de bout en bout, en autonomie ou en équipe, avec les réflexes de qualité et d'industrialisation attendus en entreprise."
+    },
     "82518980": {
       "description": "Co-fondateur et directeur de l'agence web Matière Web"
     },

--- a/letters/README.md
+++ b/letters/README.md
@@ -1,0 +1,33 @@
+# Lettres de motivation
+
+Lettres Markdown éditables, classées par thème. Chaque fichier est autonome : on peut le copier-coller dans un mail, ou l'exporter en PDF via un outil Markdown (Marked, Typora, pandoc, etc.).
+
+## Enseignement (`teaching/`)
+
+| Fichier                                                            | Cible                                                                                                  |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| [`teaching/iut-fontainebleau.md`](teaching/iut-fontainebleau.md)   | Lettre principale — IUT de Fontainebleau, vacations + perspective permanent + proposition de module Product Builder |
+| [`teaching/lycee-mathematiques.md`](teaching/lycee-mathematiques.md) | Enseignement des mathématiques en lycée                                                                |
+| [`teaching/college-techno-informatique.md`](teaching/college-techno-informatique.md) | Enseignement de la technologie / informatique en collège                                               |
+
+### Placeholders à compléter avant envoi
+
+Chaque lettre contient des champs entre crochets — `[NOM DU LYCÉE]`, `[DATE]`, `[ADRESSE]`, etc. Ouvrir le fichier, faire un `Cmd+F` sur `[` pour les repérer rapidement et les remplir manuellement.
+
+### CV joint
+
+Les lettres pointent vers l'URL CV enseignement :
+
+```
+https://elzinko.fr/fr?mode=teaching&edu=1
+```
+
+Pour générer le PDF du CV : ouvrir l'URL, faire `Cmd+P` puis « Enregistrer au format PDF ». La pastille « Bac+5 » s'affiche grâce à `&edu=1`.
+
+Pour personnaliser le sous-titre (rôle affiché sous le nom) — utile selon le poste visé — ajouter `&subtitle_fr=...` à l'URL, par exemple :
+
+```
+?mode=teaching&edu=1&subtitle_fr=Enseignant%20vacataire%20%E2%80%94%20IUT%20%2F%20secondaire
+?mode=teaching&edu=1&subtitle_fr=Professeur%20de%20math%C3%A9matiques
+?mode=teaching&edu=1&subtitle_fr=Professeur%20de%20technologie
+```

--- a/letters/teaching/college-techno-informatique.md
+++ b/letters/teaching/college-techno-informatique.md
@@ -1,0 +1,29 @@
+---
+destinataire: '[CHEF·FE D''ÉTABLISSEMENT / RESPONSABLE RH]'
+etablissement: '[NOM DU COLLÈGE]'
+adresse: '[ADRESSE]'
+date: '[DATE]'
+objet: 'Candidature — enseignement de la technologie / informatique en collège'
+---
+
+# Objet : candidature pour un poste d'enseignant en technologie et informatique
+
+Madame, Monsieur,
+
+Je vous adresse ma candidature pour un poste d'enseignant en technologie (et, le cas échéant, en informatique ou SNT) au sein de [NOM DU COLLÈGE].
+
+Je suis ingénieur informatique de formation — DUT Informatique puis Licence Professionnelle Systèmes Informatiques et Logiciels à l'IUT de Fontainebleau, après une classe préparatoire scientifique au lycée Lafayette de Champagne-sur-Seine. Depuis vingt ans, j'exerce le métier de développeur de logiciels dans des contextes très divers : grands groupes (BlaBlaCar, SNCF Réseaux, Thales, leboncoin, Mediametrie), startups (Smartch, Celsius Energy, Ecocea) et plus récemment en solopreneur, où je conçois et exploite mes propres applications, du web à l'objet connecté.
+
+Au-delà de cette pratique, l'enseignement a toujours fait partie de mon parcours : cours particuliers réguliers de mathématiques et de physique pour des élèves de collège et lycée pendant mes études (2002-2006), puis deux années consécutives de vacations en première année à l'IUT Sénart-Fontainebleau (2015-2016 et 2016-2017), sur le module web (HTML/CSS, JavaScript, outillage du développeur, intégration et déploiement continus). Ces expériences m'ont confirmé l'envie de transmettre aux plus jeunes — celles et ceux qui découvrent encore le numérique, qui se demandent comment ça marche, qui ont parfois plus de questions que de réponses.
+
+Au collège, je vois la matière « technologie » comme un formidable terrain pour faire comprendre aux élèves ce qu'il y a derrière les écrans qu'ils utilisent au quotidien : démontage et compréhension d'objets techniques, premiers pas en programmation (Scratch, micro:bit), introduction au web et aux données, esprit critique face aux outils numériques et à l'IA. Mon expérience industrielle me permet d'illustrer chaque notion par des exemples concrets et actuels, et de répondre avec justesse aux questions parfois pointues que posent les élèves de cette tranche d'âge.
+
+Cette candidature s'inscrit dans une démarche de sédentarisation : j'habite Thomery (77) et je souhaite m'investir durablement dans un établissement de la région après de longues années de missions parisiennes. Je serais heureux de pouvoir contribuer à l'équipe pédagogique de [NOM DU COLLÈGE].
+
+Je me tiens à votre disposition pour un entretien. Vous trouverez ci-joint mon CV ; il est également consultable en ligne à l'adresse [https://elzinko.fr/fr?mode=teaching&edu=1](https://elzinko.fr/fr?mode=teaching&edu=1).
+
+Je vous prie d'agréer, Madame, Monsieur, l'expression de mes salutations respectueuses.
+
+Thomas Couderc
+thomas.couderc@gmail.com — 06 61 41 27 25
+Thomery (77)

--- a/letters/teaching/iut-fontainebleau.md
+++ b/letters/teaching/iut-fontainebleau.md
@@ -1,0 +1,29 @@
+---
+destinataire: '[NOM ET FONCTION DU RESPONSABLE]'
+etablissement: 'IUT Sénart-Fontainebleau (UPEC) — site de Fontainebleau, département Informatique'
+adresse: '[ADRESSE]'
+date: '[DATE]'
+objet: 'Candidature — vacations en informatique (perspective poste permanent)'
+---
+
+# Objet : candidature pour des vacations en informatique — IUT Sénart-Fontainebleau, site de Fontainebleau
+
+Madame, Monsieur,
+
+Ancien étudiant de votre IUT — j'y ai préparé le DUT Informatique (2003-2005) puis la Licence Professionnelle Systèmes Informatiques et Logiciels (2005-2006), sur le site de Fontainebleau — je vous adresse aujourd'hui ma candidature pour des vacations dans le département Informatique, avec en perspective, si l'opportunité se présente, un poste permanent.
+
+J'ai par ailleurs déjà été vacataire dans votre IUT pendant deux années consécutives, en 2015-2016 et 2016-2017, sur le site de Sénart, où j'enseignais en première année le module web : HTML/CSS, JavaScript, outillage du développeur, intégration et déploiement continus. Cette expérience m'a confirmé ce que je pressentais depuis mes années de cours particuliers : c'est dans la transmission que je trouve le sens le plus net de mon parcours. La candidature que je vous soumets aujourd'hui prolonge donc une relation déjà existante avec votre établissement, en la rapprochant cette fois du département qui m'a formé.
+
+Depuis ma sortie de l'IUT, j'ai construit vingt ans de pratique du métier de développeur, dans des contextes aussi variés que les grands groupes (BlaBlaCar, SNCF Réseaux, Thales, Mediametrie, leboncoin), les startups (Smartch, Celsius Energy, Ecocea) et plus récemment en solopreneur — où je conçois et exploite mes propres produits numériques, de l'idée à la mise en production.
+
+Plusieurs raisons me poussent à postuler sur Fontainebleau. La première est personnelle et locale : j'habite Thomery, à quelques kilomètres seulement du site, et je souhaite m'ancrer durablement près de chez moi après une longue période de missions parisiennes et de trajets — y compris vers Sénart à l'époque de mes vacations. La seconde est affective : votre département m'a formé, et j'aimerais rendre ce qu'il m'a apporté en faisant entrer dans vos salles la réalité du métier que vos enseignants m'ont préparé à exercer.
+
+La troisième est plus concrète. Je souhaite, en complément des modules existants, vous proposer la conception d'un **module « Product Builder »** que je serais heureux de venir présenter plus en détail. L'idée : faire vivre aux étudiants un cycle produit complet — idéation, cadrage, design d'interface, développement d'un MVP, mise en production, run — en intégrant les outils IA modernes (prompt engineering, agents LLM, RAG, MCP) comme accélérateurs réalistes du métier. À la sortie du module, les étudiants auraient livré un vrai produit, avec les réflexes de qualité et d'industrialisation attendus en entreprise. C'est un format qui me semble compléter utilement votre cursus en répondant à une demande croissante du marché, que j'observe quotidiennement côté employeur.
+
+Je me tiens à votre disposition pour un entretien, idéalement avant la prochaine rentrée afin de pouvoir démarrer les vacations dès la rentrée prochaine. Vous trouverez ci-joint mon CV ; il est également consultable en ligne à l'adresse [https://elzinko.fr/fr?mode=teaching&edu=1](https://elzinko.fr/fr?mode=teaching&edu=1).
+
+Je vous prie d'agréer, Madame, Monsieur, l'expression de mes salutations respectueuses.
+
+Thomas Couderc
+thomas.couderc@gmail.com — 06 61 41 27 25
+Thomery (77)

--- a/letters/teaching/lycee-mathematiques.md
+++ b/letters/teaching/lycee-mathematiques.md
@@ -1,0 +1,27 @@
+---
+destinataire: '[CHEF·FE D''ÉTABLISSEMENT / RESPONSABLE RH]'
+etablissement: '[NOM DU LYCÉE]'
+adresse: '[ADRESSE]'
+date: '[DATE]'
+objet: 'Candidature — enseignement des mathématiques en lycée'
+---
+
+# Objet : candidature pour un poste d'enseignant de mathématiques
+
+Madame, Monsieur,
+
+Je vous adresse ma candidature pour un poste d'enseignant de mathématiques au sein de [NOM DU LYCÉE], en classe de seconde, première ou terminale selon vos besoins.
+
+Mon parcours est scientifique : baccalauréat S spécialité mathématiques au lycée François 1er de Fontainebleau, puis classes préparatoires PTSI/PSI au lycée Lafayette de Champagne-sur-Seine. Pendant ces années de prépa puis pendant mes études d'informatique (DUT puis Licence Pro à l'IUT de Fontainebleau, 2003-2006), j'ai donné des cours particuliers réguliers de mathématiques et de physique à des élèves du collège et du lycée, du niveau 6ᵉ jusqu'à la terminale S. Cette expérience de tutorat — diagnostic des lacunes, reformulation patiente, exercices progressifs, préparation aux contrôles et au baccalauréat — m'a appris ce qu'enseigner veut dire au quotidien, élève par élève.
+
+Vingt années de pratique professionnelle dans l'industrie logicielle (BlaBlaCar, SNCF, Thales, leboncoin, Mediametrie, et plus récemment mes propres produits en tant que solopreneur) m'ont par ailleurs maintenu en contact étroit avec les mathématiques appliquées — modélisation, statistiques, algorithmique, traitement du signal. Cette expérience me permet d'illustrer les notions abstraites du programme par des exemples concrets et actuels, et de répondre aux questions du type « à quoi ça sert ? » que tout élève finit par poser.
+
+Trois raisons motivent cette candidature aujourd'hui. D'abord le désir de transmettre, qui ne m'a jamais quitté depuis mes années de cours particuliers et que j'ai retrouvé intact en enseignant deux années en première année d'IUT. Ensuite le souhait de me sédentariser dans la région de Fontainebleau, où je vis aujourd'hui à Thomery, après une longue période de missions parisiennes. Enfin la conviction que les mathématiques se transmettent mieux quand on a soi-même eu à les utiliser dans la durée pour résoudre des problèmes concrets.
+
+Je me tiens à votre disposition pour un entretien et pour vous présenter plus en détail ma motivation et la façon dont je pourrais m'inscrire dans votre équipe pédagogique. Vous trouverez ci-joint mon CV ; il est également consultable en ligne à l'adresse [https://elzinko.fr/fr?mode=teaching&edu=1](https://elzinko.fr/fr?mode=teaching&edu=1).
+
+Je vous prie d'agréer, Madame, Monsieur, l'expression de mes salutations respectueuses.
+
+Thomas Couderc
+thomas.couderc@gmail.com — 06 61 41 27 25
+Thomery (77)

--- a/lib/cv-compose.ts
+++ b/lib/cv-compose.ts
@@ -35,6 +35,8 @@ export interface ExperienceJob {
   startDate: string;
   endDate?: string;
   display?: boolean;
+  /** Restrict visibility to a specific CV mode (e.g. `teaching`). Absent ⇒ visible in all modes. */
+  displayMode?: string;
   roleId: string;
   frameworks: string[];
 }
@@ -56,6 +58,8 @@ export interface ExperienceProject {
   bullets: Array<{ id: string; text: string; link?: string }>;
   tags: Array<{ id: string; name: string }>;
   display?: boolean;
+  /** Restrict visibility to a specific CV mode (e.g. `teaching`). Absent ⇒ visible in all modes. */
+  displayMode?: string;
 }
 
 export interface ExperienceHobby {
@@ -87,7 +91,12 @@ export interface LocaleBundle {
     emailTitle: string;
     locationTitle: string;
   };
-  about: { title: string; text: string; textCdi: string };
+  about: {
+    title: string;
+    text: string;
+    textCdi: string;
+    textTeaching?: string;
+  };
   ui: {
     skillsTitle: string;
     studiesTitle: string;
@@ -103,7 +112,14 @@ export interface LocaleBundle {
     locale: string;
     seo: { description: string; title: string };
   };
-  domains: Record<string, { description: string; descriptionCdi: string }>;
+  domains: Record<
+    string,
+    {
+      description: string;
+      descriptionCdi: string;
+      descriptionTeaching?: string;
+    }
+  >;
   jobs: Record<
     string,
     {
@@ -159,6 +175,7 @@ export function composeCvSnapshot(
     name: d.name,
     description: locale.domains[d.id].description,
     descriptionCdi: locale.domains[d.id].descriptionCdi,
+    descriptionTeaching: locale.domains[d.id].descriptionTeaching,
     position: d.position,
     competencies: d.competencyIds.map(resolveTechNoLink),
   }));
@@ -170,6 +187,7 @@ export function composeCvSnapshot(
     const fwIds = lj.frameworks ?? ej.frameworks;
     const out: Record<string, unknown> = {};
     if (ej.display !== undefined) out.display = ej.display;
+    if (ej.displayMode !== undefined) out.displayMode = ej.displayMode;
     out.client = ej.client;
     if (ej.clientUrl !== undefined) out.clientUrl = ej.clientUrl;
     out.location = lj.location;
@@ -202,6 +220,7 @@ export function composeCvSnapshot(
     const out: Record<string, unknown> = {};
     out.id = ep.id;
     if (ep.display !== undefined) out.display = ep.display;
+    if (ep.displayMode !== undefined) out.displayMode = ep.displayMode;
     out.name = ep.name;
     if (lp.title !== undefined) out.title = lp.title;
     if (ep.link !== undefined) out.link = ep.link;

--- a/lib/cv-contract-text.ts
+++ b/lib/cv-contract-text.ts
@@ -1,25 +1,42 @@
 import type { ContractType } from '@/data/offers/types';
 
+export type CvMode = 'teaching';
+
 /**
- * Resolve about/profile text based on contract type.
- * CDI uses `textCdi` if available, otherwise falls back to `text` (freelance default).
+ * Resolve about/profile text based on contract type and/or CV mode.
+ * Teaching mode wins over CDI when both are set (they're meant to be exclusive).
  */
 export function resolveAboutText(
-  about: { text?: string; textCdi?: string } | undefined | null,
+  about:
+    | { text?: string; textCdi?: string; textTeaching?: string }
+    | undefined
+    | null,
   contract?: ContractType,
+  mode?: CvMode,
 ): string {
+  if (mode === 'teaching' && about?.textTeaching) return about.textTeaching;
   if (contract === 'cdi' && about?.textCdi) return about.textCdi;
   return about?.text || '';
 }
 
 /**
- * Resolve domain description based on contract type.
- * CDI uses `descriptionCdi` if available, otherwise falls back to `description` (freelance default).
+ * Resolve domain description based on contract type and/or CV mode.
+ * Teaching mode wins over CDI when both are set.
  */
 export function resolveDomainDescription(
-  domain: { description?: string; descriptionCdi?: string } | undefined | null,
+  domain:
+    | {
+        description?: string;
+        descriptionCdi?: string;
+        descriptionTeaching?: string;
+      }
+    | undefined
+    | null,
   contract?: ContractType,
+  mode?: CvMode,
 ): string {
+  if (mode === 'teaching' && domain?.descriptionTeaching)
+    return domain.descriptionTeaching;
   if (contract === 'cdi' && domain?.descriptionCdi)
     return domain.descriptionCdi;
   return domain?.description || '';


### PR DESCRIPTION
## Summary

Adds a teaching-oriented CV variant for IUT vacations and secondary-education applications, alongside 3 editable motivation letters.

- **New `?mode=teaching` query param** — mirrors the existing `?contract=cdi` pattern. Switches profile + domains to pedagogy-focused text (`textTeaching` / `descriptionTeaching`), surfaces teaching jobs and the Product Builder module proposal, hides Malt.
- **New `displayMode` field** on jobs/projects — items tagged `displayMode: "teaching"` only appear in teaching mode; filtered out of neutral, CDI, and short CV (preserves regression-free behavior for existing URLs).
- **Data** — IUT Sénart-Fontainebleau vacations (2015-2017, site de Sénart), private tutoring 2002-2006 (maths/physique, collège/lycée), Product Builder module proposal as a project.
- **Letters** — 3 Markdown letters under [`letters/teaching/`](letters/teaching/) with placeholders to fill before sending:
  - [`iut-fontainebleau.md`](letters/teaching/iut-fontainebleau.md) — primary, leverages the prior vacataire link at the same IUT (Sénart) for a candidacy on the Fontainebleau site.
  - [`lycee-mathematiques.md`](letters/teaching/lycee-mathematiques.md)
  - [`college-techno-informatique.md`](letters/teaching/college-techno-informatique.md)

## Canonical URL

```
/fr?mode=teaching&edu=1
```

Optional `&subtitle_fr=...` to tailor the role displayed under the header.

## Notes for reviewer

- The `mode` param is orthogonal to `contract` (teaching wins when both are set, by convention — they aren't meant to be combined).
- EN locale gets the new jobs/project translations (otherwise `cv-compose` would throw on `/en`), but `textTeaching` / `descriptionTeaching` are FR-only by design (target audience is the French education system).
- Short CV (`/fr/short`) doesn't support modes — any `displayMode`-tagged item is hidden there.

## Test plan

- [x] `npm run test:unit` — 149 tests pass
- [x] `npm run lint` + `npm run prettier:check` — clean
- [x] `GET /fr` (neutral) — no teaching content visible
- [x] `GET /fr?contract=cdi` — no teaching content visible (regression)
- [x] `GET /fr?mode=teaching&edu=1` — teaching profile, domains, jobs, project all visible
- [x] `GET /fr/short` — no teaching content (modes not supported there)
- [x] `GET /en` and `GET /en?mode=teaching` — both 200, EN falls back to default texts where teaching translations are absent
- [ ] Manual PDF export via Cmd+P on `/fr?mode=teaching&edu=1` — visual review of pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)