### PR TITLE
feat(cv): add vanity short links (/resilience → targeted CV)

### DIFF
--- a/lib/short-links.ts
+++ b/lib/short-links.ts
@@ -1,0 +1,57 @@
+/**
+ * Liens courts « vanity » : un slug racine (ex. `/resilience`) → l'URL d'un CV
+ * personnalisé (`/fr?company=…&requirement=…`). Résolus par le middleware
+ * AVANT la logique de locale, afin que `elzinko.fr/<slug>` redirige en un seul
+ * saut vers la version ciblée du CV.
+ *
+ * Pour ajouter un lien : une entrée dans `SHORT_LINKS`. La destination est
+ * construite via `cvOfferTarget()` pour garantir un encodage correct.
+ */
+
+interface CvOfferParams {
+  company: string;
+  titleFr: string;
+  subtitleFr: string;
+  contract?: 'cdi' | 'freelance';
+  /** Chaque entrée : `Libellé:mot1,mot2` (ordre = ordre d'affichage). */
+  requirements: string[];
+}
+
+/** Construit une URL `/fr?…` correctement encodée pour une offre. */
+export function cvOfferTarget(params: CvOfferParams): string {
+  const sp = new URLSearchParams();
+  sp.set('company', params.company);
+  sp.set('title_fr', params.titleFr);
+  sp.set('subtitle_fr', params.subtitleFr);
+  if (params.contract) sp.set('contract', params.contract);
+  for (const req of params.requirements) sp.append('requirement', req);
+  return `/fr?${sp.toString()}`;
+}
+
+/** Registre des liens courts (clé = slug en minuscules, sans `/`). */
+export const SHORT_LINKS: Record<string, string> = {
+  resilience: cvOfferTarget({
+    company: 'Resilience',
+    titleFr: 'Développeur fullstack Kotlin',
+    subtitleFr: 'Développeur fullstack Kotlin · Java · Spring Boot',
+    contract: 'freelance',
+    requirements: [
+      'Kotlin:kotlin',
+      'Java:java',
+      'Spring Boot:spring-boot,spring boot,springboot,spring',
+      'PostgreSQL:postgresql,postgres',
+      'Kubernetes & Docker:kubernetes,docker,openshift,rancher',
+      'APIs REST:rest,openapi,swagger,ktor',
+    ],
+  }),
+};
+
+/**
+ * Résout un pathname (`/resilience`, `/Resilience/`) vers sa cible, ou `null`
+ * si aucun lien court ne correspond.
+ */
+export function resolveShortLink(pathname: string): string | null {
+  const slug = pathname.replace(/^\/+|\/+$/g, '').toLowerCase();
+  if (!slug) return null;
+  return SHORT_LINKS[slug] ?? null;
+}

--- a/lib/short-links.unit.test.ts
+++ b/lib/short-links.unit.test.ts
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { cvOfferTarget, resolveShortLink, SHORT_LINKS } from './short-links';
+
+test('cvOfferTarget encodes company, title, subtitle and requirements', () => {
+  const target = cvOfferTarget({
+    company: 'Resilience',
+    titleFr: 'Développeur fullstack Kotlin',
+    subtitleFr: 'Backend Kotlin · Java',
+    contract: 'freelance',
+    requirements: ['Kotlin:kotlin', 'Java:java'],
+  });
+  assert.ok(target.startsWith('/fr?'));
+  const sp = new URLSearchParams(target.slice('/fr?'.length));
+  assert.equal(sp.get('company'), 'Resilience');
+  assert.equal(sp.get('title_fr'), 'Développeur fullstack Kotlin');
+  assert.equal(sp.get('subtitle_fr'), 'Backend Kotlin · Java');
+  assert.equal(sp.get('contract'), 'freelance');
+  assert.deepEqual(sp.getAll('requirement'), ['Kotlin:kotlin', 'Java:java']);
+});
+
+test('cvOfferTarget omits contract when not provided', () => {
+  const target = cvOfferTarget({
+    company: 'X',
+    titleFr: 'T',
+    subtitleFr: 'S',
+    requirements: ['Kotlin:kotlin'],
+  });
+  const sp = new URLSearchParams(target.slice('/fr?'.length));
+  assert.equal(sp.get('contract'), null);
+});
+
+test('resolveShortLink resolves a known slug', () => {
+  const target = resolveShortLink('/resilience');
+  assert.ok(target);
+  assert.ok(target!.includes('company=Resilience'));
+});
+
+test('resolveShortLink is case-insensitive and tolerates trailing slash', () => {
+  assert.equal(resolveShortLink('/Resilience'), SHORT_LINKS.resilience);
+  assert.equal(resolveShortLink('/resilience/'), SHORT_LINKS.resilience);
+});
+
+test('resolveShortLink returns null for unknown or empty paths', () => {
+  assert.equal(resolveShortLink('/unknown'), null);
+  assert.equal(resolveShortLink('/'), null);
+  assert.equal(resolveShortLink(''), null);
+  assert.equal(resolveShortLink('/fr'), null);
+});
+
+test('resolveShortLink target points at the French CV with requirements', () => {
+  const target = resolveShortLink('/resilience')!;
+  const sp = new URLSearchParams(target.slice('/fr?'.length));
+  assert.equal(
+    sp.get('subtitle_fr'),
+    'Développeur fullstack Kotlin · Java · Spring Boot',
+  );
+  assert.ok(sp.getAll('requirement').some((r) => r.startsWith('Kotlin:')));
+  assert.equal(sp.getAll('requirement').length, 6);
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { NextRequest } from 'next/server';
 
 import { i18n } from './i18n-config';
+import { resolveShortLink } from './lib/short-links';
 
 import { match as matchLocale } from '@formatjs/intl-localematcher';
 import Negotiator from 'negotiator';
@@ -31,6 +32,15 @@ export function middleware(request: NextRequest) {
         status: 404,
       });
     }
+  }
+
+  // Liens courts « vanity » (ex. /resilience) → CV ciblé, avant la locale.
+  const shortLinkTarget = resolveShortLink(pathname);
+  if (shortLinkTarget) {
+    return NextResponse.redirect(
+      new URL(`${basePath}${shortLinkTarget}`, request.url),
+      307,
+    );
   }
 
   // Case where the user is accessing the root path


### PR DESCRIPTION
## Summary

Adds recruiter-friendly **vanity short links**: hitting `elzinko.fr/<slug>` redirects (307) to a pre-built personalized CV (`/fr?company=…&requirement=…`) in a single hop.

- The redirect runs in **middleware**, *before* the locale logic, so the bare `/<slug>` path works without a locale prefix.
- Slug→target registry lives in `lib/short-links.ts`, with `cvOfferTarget()` for correct query encoding. Unit-tested (`lib/short-links.unit.test.ts`).
- **First entry:** `/resilience` → `Développeur fullstack Kotlin · Java · Spring Boot` targeted CV (Resilience mission).

## Adding more

One entry in `SHORT_LINKS` per recruiter/client → `elzinko.fr/<client>`.

## Verification

- `/resilience` → 307 → `/fr?company=Resilience…` → 200, correct subtitle + 6 job-fit tiles (tested locally via dev server).
- `npm run lint` ✓ · 149 unit tests ✓ · `next build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)