### PR TITLE
fix: impression dense (proche du web) + Adéquation ≤4 + reformulation Celsius

### DIFF
--- a/app/[lang]/jobs.tsx
+++ b/app/[lang]/jobs.tsx
@@ -33,7 +33,7 @@ export default async function jobs({
   const recapLine = formatRemainingClientsRecapForFullCv(visibleJobs, locale);
 
   return (
-    <div className="cv-print-jobs-group print-preview:order-[90] print:order-[90]">
+    <div className="cv-print-jobs-group print-preview:order-[90] print:order-[90] print:break-before-page">
       <section
         id="jobs"
         className="mt-10 break-before-page print:break-before-auto max-md:mt-0"

--- a/app/[lang]/jobs.tsx
+++ b/app/[lang]/jobs.tsx
@@ -33,7 +33,7 @@ export default async function jobs({
   const recapLine = formatRemainingClientsRecapForFullCv(visibleJobs, locale);
 
   return (
-    <div className="cv-print-jobs-group print-preview:order-[90] print:order-[90] print:break-before-page">
+    <div className="cv-print-jobs-group print-preview:order-[90] print:order-[90]">
       <section
         id="jobs"
         className="mt-10 break-before-page print:break-before-auto max-md:mt-0"
@@ -45,7 +45,7 @@ export default async function jobs({
           canToggleDetails={detailLevel === 'full'}
         >
           {visibleJobs.map((job: any, index: number) => (
-            <li key={job.client + index}>
+            <li key={job.client + index} className="print:break-inside-avoid">
               <Job
                 job={job}
                 locale={locale}

--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -41,7 +41,7 @@ export default function HeaderContent({
   return (
     <div
       className={`header-content pb-0 pt-2 max-md:pt-0 md:py-12 ${
-        compactPrint ? 'print:py-8' : 'print:py-12'
+        compactPrint ? 'print:py-8' : 'print:py-4'
       }`}
     >
       <div className="flex w-full items-stretch gap-4 print:gap-4 md:gap-6">

--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -42,10 +42,14 @@ export default function JobFitSection({
   const defaults = useMemo(() => computeDefaultMatchData(lang), [lang]);
 
   const data: MatchDisplayData = offerData ?? defaults;
+  // Borne le nombre de groupes « Adéquation poste » : au-delà de ~4, la section
+  // s'allonge et nuit à la lisibilité (et déborde la page 1 à l'impression).
+  // Les entrées sont déjà triées par pertinence ; on garde les premières.
+  const FULL_PROFILE_MATCH_MAX = 4;
   const entries =
     variant === 'compact'
       ? data.entries.slice(0, SHORT_PROFILE_MATCH_MAX)
-      : data.entries;
+      : data.entries.slice(0, FULL_PROFILE_MATCH_MAX);
   const l = lang as MatchYearsLang;
 
   const sectionTitle = lang === 'en' ? 'Job fit' : 'Adequation poste';

--- a/components/OfferTailoredShell.tsx
+++ b/components/OfferTailoredShell.tsx
@@ -117,7 +117,7 @@ export default function OfferTailoredShell({
             </Suspense>
             {/* Coordonnées : après Adéquation poste, même placement que le CV court. */}
             {headerContactStrip.email && (
-              <section className="cv-mobile-section-mt print-preview:order-[30] print:order-[30]">
+              <section className="cv-mobile-section-mt print-preview:order-[30] print:order-[30] print:break-inside-avoid">
                 <div className="border-b pb-1">
                   <SectionHeadingAts
                     section="contact"

--- a/data/cv/locales/en.json
+++ b/data/cv/locales/en.json
@@ -223,7 +223,7 @@
       "location": "Clamart",
       "roleName": "Full Stack Consultant",
       "description": "",
-      "descriptionShort": "End-to-end design and development of the information system: a full monitoring application for heat-pump geothermal heating in large buildings.",
+      "descriptionShort": "Full-stack design and development of a real-time monitoring platform for heat-pump geothermal heating, across large buildings.",
       "bullets": [
         {
           "id": "82548176",

--- a/data/cv/locales/fr.json
+++ b/data/cv/locales/fr.json
@@ -227,7 +227,7 @@
       "location": "Clamart",
       "roleName": "Consultant Full Stack",
       "description": "",
-      "descriptionShort": "Conception et développement de bout en bout du SI : application de monitoring complète du chauffage géothermique par pompe à chaleur pour grands bâtiments.",
+      "descriptionShort": "Conception et développement full-stack d'une plateforme de supervision temps réel du chauffage géothermique par pompe à chaleur, pour de grands bâtiments.",
       "bullets": [
         {
           "id": "82548179",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,6 +57,8 @@
    */
   .cv-full-cv-print-root {
     @apply flex flex-col gap-6 print:mt-0 max-md:mt-20;
+    /* Impression plus dense (proche de la vue web) : gaps inter-sections réduits. */
+    @apply print:gap-3;
   }
 
   .cv-full-cv-print-root > section,


### PR DESCRIPTION
Suite aux retours sur le CV iad Engineering Manager (impression trop aérée, trop de job-fit, texte mal tourné).

## 1. Impression plus dense (print-only — web & mobile inchangés)

Analyse (largeur A4) : l'en-tête prenait **252px** (dont 96px de `py-12`), l'« Adéquation poste » affichait **tous** les groupes → tout ce qui précède l'Expérience dépassait une page (1369px > 1123px).

- En-tête print : `py-12` → `py-4` (−64px).
- Gaps inter-sections print : `gap-6` → `gap-3`.
- **« Adéquation poste » bornée à 4 groupes** (`FULL_PROFILE_MATCH_MAX`) — sur le CV long aussi (avant : illimité). Les entrées sont triées par pertinence ; ordre pilotable par l'URL.

## 2. Sauts de page « propres » (au lieu d'un saut forcé)

L'approche « saut forcé avant l'Expérience » gaspillait une demi-page. Remplacée par :
- `break-inside: avoid` sur **chaque expérience** (jamais coupée entre 2 pages) et sur **Coordonnées** (bloc non scindé). Coupures naturelles, sans demi-page vide. Print-only.

**Résultat** : page 1 = cover dense (en-tête, profil, compétences, adéquation×4) ; page 2 = coordonnées + expérience, chaque job intact.

## 3. Reformulation Celsius Energy (FR + EN)

« Conception et développement de bout en bout du SI : … » → « **Conception et développement full-stack d'une plateforme de supervision temps réel** du chauffage géothermique par pompe à chaleur, pour de grands bâtiments. »

Vérifié : `next build` ✅, `next lint` ✅, rendu PDF (page 1 cover / page 2 expérience, jobs non coupés).

> Photo & Bac+5 = URL : `&photo=1`, retirer `&edu=1`. Rien à déployer pour ça.

🤖 Generated with [Claude Code](https://claude.com/claude-code)