### PR TITLE
fix: Adéquation poste — toutes les entrées à l'écran, ≤4 à l'impression

### DIFF
--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -42,14 +42,15 @@ export default function JobFitSection({
   const defaults = useMemo(() => computeDefaultMatchData(lang), [lang]);
 
   const data: MatchDisplayData = offerData ?? defaults;
-  // Borne le nombre de groupes « Adéquation poste » : au-delà de ~4, la section
-  // s'allonge et nuit à la lisibilité (et déborde la page 1 à l'impression).
-  // Les entrées sont déjà triées par pertinence ; on garde les premières.
+  // « Adéquation poste » : à l'ÉCRAN on affiche TOUTES les entrées (web exhaustif,
+  // on scrolle) ; à l'IMPRESSION on borne à 4 (page 1 nette). Le masquage est
+  // print-only, par entrée, via `print:hidden` au-delà du seuil (cf. <li>).
+  // Entrées déjà triées par pertinence → on garde les 4 premières en print.
   const FULL_PROFILE_MATCH_MAX = 4;
   const entries =
     variant === 'compact'
       ? data.entries.slice(0, SHORT_PROFILE_MATCH_MAX)
-      : data.entries.slice(0, FULL_PROFILE_MATCH_MAX);
+      : data.entries;
   const l = lang as MatchYearsLang;
 
   const sectionTitle = lang === 'en' ? 'Job fit' : 'Adequation poste';
@@ -146,7 +147,9 @@ export default function JobFitSection({
           return (
             <li
               key={`${index}-${entry.label}`}
-              className="flex flex-wrap items-baseline gap-x-2 gap-y-1 print:gap-x-1.5"
+              className={`flex flex-wrap items-baseline gap-x-2 gap-y-1 print:gap-x-1.5${
+                index >= FULL_PROFILE_MATCH_MAX ? ' print:hidden' : ''
+              }`}
             >
               <Pill color="match" metric={yearsLabel}>
                 {entry.label}


### PR DESCRIPTION
Suite de [#84](https://github.com/elzinko/my-resume/pull/84) : le cap à 4 groupes « Adéquation poste » s'appliquait à l'écran **et** à l'impression. On le rend **print-only**.

- **Écran** : toutes les entrées (on scrolle, autant être exhaustif).
- **Impression** : bornées à 4 via `print:hidden` au-delà du seuil (page 1 nette).

Vérifié sur le CV iad (6 requirements) — comptage DOM : **écran = 6, print = 4** ; PDF page 1 affiche Leadership/Vue/Node/TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)