### PR TITLE
fix: coordonnées en page 1 à l'impression (en-tête print compact)

### DIFF
--- a/app/[lang]/jobs.tsx
+++ b/app/[lang]/jobs.tsx
@@ -36,7 +36,9 @@ export default async function jobs({
     <div className="cv-print-jobs-group print-preview:order-[90] print:order-[90]">
       <section
         id="jobs"
-        className="mt-10 break-before-page print:break-before-auto max-md:mt-0"
+        // À l'impression : Expérience démarre TOUJOURS en page 2 (les coordonnées
+        // ferment la page 1). `print:mt-0` → top uniforme via la marge @page.
+        className="mt-10 break-before-page print:mt-0 print:break-before-page max-md:mt-0"
       >
         <ExperienceSection
           section="jobs"

--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -41,7 +41,7 @@ export default function HeaderContent({
   return (
     <div
       className={`header-content pb-0 pt-2 max-md:pt-0 md:py-12 ${
-        compactPrint ? 'print:py-8' : 'print:py-4'
+        compactPrint ? 'print:py-8' : 'print:!py-2'
       }`}
     >
       <div className="flex w-full items-stretch gap-4 print:gap-4 md:gap-6">


### PR DESCRIPTION
## Problème
À l'impression, la section **Coordonnées** débordait en page 2 — un recruteur ne voyait plus le contact en page 1.

## Cause (mesurée)
L'en-tête faisait **216px** en PDF : `md:py-12` (~96px de padding) s'applique aussi en print (A4 ≥ md) et **écrasait** `print:py-0` (ordre de cascade Tailwind). Du coup la page 1 débordait de ~55px et `break-inside-avoid` basculait Coordonnées en entier page 2.

## Fix (2 fichiers, 6 lignes)
- **`HeaderContent`** : `print:!py-2` (important) force un en-tête compact en print → ~136px. Récupère ~80px. **Écran inchangé** (`md:py-12` conservé hors print).
- **`jobs.tsx`** : `print:break-before-page` → « Expérience professionnelle » démarre **toujours** en page 2, top uniforme via `@page` (`print:mt-0`).

## Résultat (vérifié sur le CV iad, mesure DOM A4 + PDF)
- **Page 1** : en-tête + Profile + Compétences + Adéquation (4) + **Coordonnées** (25px de marge).
- **Page 2** : Expérience professionnelle (haut de page).

> Note : la marge de 25px dépend du contenu (profil très long → pourrait redéborder). Si ça arrive un jour, on passera le contact en une ligne compacte (robuste). Pour les CV typiques, c'est bon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)