### PR TITLE
feat: palette teal-500 plus lisible + cohérence titres Profile/Compétences + « Adéquation »

### DIFF
--- a/app/[lang]/about.tsx
+++ b/app/[lang]/about.tsx
@@ -22,14 +22,14 @@ export default async function About({
   return (
     <section
       id="about"
-      className="mb-1 mt-4 pb-1 print-preview:order-[10] max-md:!mt-0 print:order-[10]"
+      className="mb-1 mt-4 pb-1 print-preview:order-[10] print:order-[10] max-md:!mt-0"
     >
       <div className="border-b pb-1">
         <SectionHeadingAts
           section="about"
           locale={locale}
           title={data?.about?.title}
-          className="min-w-0 text-2xl font-semibold text-cv-section"
+          className="min-w-0 text-2xl font-semibold text-cv-tag-text"
         />
       </div>
       <p className="mt-4 text-cv-body-muted">

--- a/app/[lang]/domains.tsx
+++ b/app/[lang]/domains.tsx
@@ -25,12 +25,12 @@ export default async function domains({
           à l'écran ce titre est porté par la sidebar `skills.tsx` (donc pas de
           doublon) ; en PDF la sidebar est masquée, et ce titre donne aux ATS
           l'anchor « Skills » juste au-dessus des compétences (tags Agile/Dev/Ops). */}
-      <div className="mb-2 hidden border-b pb-1 print:block print-preview:block">
+      <div className="mb-2 hidden border-b pb-1 print-preview:block print:block">
         <SectionHeadingAts
           section="skills"
           locale={locale}
           title={data?.skillsTitle?.title}
-          className="min-w-0 text-2xl font-semibold text-cv-tag-text"
+          className="min-w-0 text-2xl font-semibold text-cv-section"
         />
       </div>
       <div className="cv-domains-grid">

--- a/app/[lang]/skills.tsx
+++ b/app/[lang]/skills.tsx
@@ -31,7 +31,7 @@ export default async function skills({
         section="skills"
         locale={locale}
         title={data?.skillsTitle?.title}
-        className="border-b pb-1 text-2xl font-semibold text-cv-tag-text"
+        className="border-b pb-1 text-2xl font-semibold text-cv-section"
       />
       <div className="mt-4 flex flex-wrap gap-2">
         {data?.allSkillsModels?.map((skill: any) => (

--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -27,7 +27,7 @@ interface JobFitSectionProps {
 }
 
 /**
- * Section « Adequation poste » :
+ * Section « Adéquation poste » :
  * - full : une ligne par entree (badge + detail clients ou texte)
  * - compact : pastilles inline (CV court)
  */
@@ -53,7 +53,7 @@ export default function JobFitSection({
       : data.entries;
   const l = lang as MatchYearsLang;
 
-  const sectionTitle = lang === 'en' ? 'Job fit' : 'Adequation poste';
+  const sectionTitle = lang === 'en' ? 'Job fit' : 'Adéquation poste';
 
   /* ── Compact : pastilles inline uniquement (CV court) ── */
   if (variant === 'compact') {

--- a/components/ShortHeaderJobFitPills.tsx
+++ b/components/ShortHeaderJobFitPills.tsx
@@ -28,7 +28,7 @@ export default function ShortHeaderJobFitPills({
   const listLabel =
     lang === 'en'
       ? 'Role fit at a glance, years of experience per requirement'
-      : 'Adequation poste (apercu), annees d\u2019experience par exigence';
+      : 'Adéquation poste (apercu), annees d\u2019experience par exigence';
 
   return (
     <div

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,7 +34,7 @@ module.exports = {
     extend: {
       colors: {
         cv: {
-          section: colors.teal[300],
+          section: colors.teal[500],
           'tag-text': colors.blue[300],
           'tag-border': colors.blue[400],
           'tag-text-hover': colors.blue[200],


### PR DESCRIPTION
## Couleurs
- **`cv-section` : teal-300 → teal-500** — plus dense et lisible (le teal clair « vibrait » sur blanc), reste pastel. Impacte rôle, Agile/Dev/Ops, Compétences, pills.
- **Cohérence des titres** : **Profile → bleu** (comme le nom), **Compétences → teal** (comme ses sous-blocs Agile/Dev/Ops) — écran **et** impression. Avant : Profile teal / Compétences bleu (incohérent).

## Typo
- « Adequation poste » → « **Adéquation poste** » (titre + aria-label).

Vérifié via Playwright (écran + PDF) sur le CV iad : Profile bleu, Compétences/Agile/Dev/Ops teal-500, Adéquation accentuée, Coordonnées toujours en page 1.

À suivre (Lot B) : overrides couleur par bloc dans l'URL/API, règle page-break titres non-orphelins, contenu Solopreneur/Projets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)