### PR TITLE
feat: filet de section coloré (couleur du titre) + anti-titre-orphelin

### DIFF
--- a/app/[lang]/about.tsx
+++ b/app/[lang]/about.tsx
@@ -24,7 +24,7 @@ export default async function About({
       id="about"
       className="mb-1 mt-4 pb-1 print-preview:order-[10] print:order-[10] max-md:!mt-0"
     >
-      <div className="border-b pb-1">
+      <div className="border-b border-cv-tag-text/50 pb-1">
         <SectionHeadingAts
           section="about"
           locale={locale}

--- a/app/[lang]/domains.tsx
+++ b/app/[lang]/domains.tsx
@@ -25,7 +25,7 @@ export default async function domains({
           à l'écran ce titre est porté par la sidebar `skills.tsx` (donc pas de
           doublon) ; en PDF la sidebar est masquée, et ce titre donne aux ATS
           l'anchor « Skills » juste au-dessus des compétences (tags Agile/Dev/Ops). */}
-      <div className="mb-2 hidden border-b pb-1 print-preview:block print:block">
+      <div className="mb-2 hidden border-b border-cv-section/50 pb-1 print-preview:block print:block">
         <SectionHeadingAts
           section="skills"
           locale={locale}

--- a/app/[lang]/projects.tsx
+++ b/app/[lang]/projects.tsx
@@ -49,7 +49,7 @@ export default async function projects({
           section="projects"
           locale={locale}
           title={data?.projectsTitle?.title ?? 'Projects'}
-          className="border-b pb-1 text-2xl font-semibold text-cv-tag-text"
+          className="border-b border-cv-tag-text/50 pb-1 text-2xl font-semibold text-cv-tag-text"
         />
         <ul className="cv-section-simple-list cv-cq-project-list max-md:mt-6">
           {projectsOrdered.map((project: any) => (

--- a/app/[lang]/skills.tsx
+++ b/app/[lang]/skills.tsx
@@ -31,7 +31,7 @@ export default async function skills({
         section="skills"
         locale={locale}
         title={data?.skillsTitle?.title}
-        className="border-b pb-1 text-2xl font-semibold text-cv-section"
+        className="border-b border-cv-section/50 pb-1 text-2xl font-semibold text-cv-section"
       />
       <div className="mt-4 flex flex-wrap gap-2">
         {data?.allSkillsModels?.map((skill: any) => (

--- a/app/[lang]/studies.tsx
+++ b/app/[lang]/studies.tsx
@@ -30,7 +30,7 @@ export default async function studies({
         section="studies"
         locale={locale}
         title={data?.studiesTitle?.title}
-        className="border-b pb-1 text-2xl font-semibold text-purple-300"
+        className="border-b border-purple-300/50 pb-1 text-2xl font-semibold text-purple-300"
       />
       <ul className="cv-section-simple-list">
         {studiesOrdered.map((study: any) => (

--- a/components/ExperienceSection.tsx
+++ b/components/ExperienceSection.tsx
@@ -41,7 +41,7 @@ export default function ExperienceSection({
 
   return (
     <>
-      <div className="flex items-end justify-between gap-2 border-b pb-1 print:break-after-avoid">
+      <div className="flex items-end justify-between gap-2 border-b border-cv-jobs/50 pb-1 print:break-after-avoid">
         <SectionHeadingAts
           section={section}
           locale={locale}

--- a/components/HobbiesDisplay.tsx
+++ b/components/HobbiesDisplay.tsx
@@ -29,7 +29,7 @@ export default function HobbiesDisplay({
         section="hobbies"
         locale={locale}
         title={title}
-        className="border-b pb-1 text-2xl font-semibold text-orange-300"
+        className="border-b border-orange-300/50 pb-1 text-2xl font-semibold text-orange-300"
       />
       <ul className="cv-section-simple-list cv-cq-link-list max-md:mt-6">
         {items.map((hobby) => (

--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -59,7 +59,7 @@ export default function JobFitSection({
   if (variant === 'compact') {
     return (
       <section id="job-fit" className="mb-6" aria-label={sectionTitle}>
-        <h2 className="border-b pb-1 text-2xl font-semibold text-orange-300">
+        <h2 className="border-b border-orange-300/50 pb-1 text-2xl font-semibold text-orange-300">
           {sectionTitle}
         </h2>
         <div className="cv-section-body-gap flex flex-wrap items-center gap-1.5 print:gap-1">
@@ -108,7 +108,7 @@ export default function JobFitSection({
       className="cv-mobile-section-mt print-preview:order-[25] print:order-[25] max-md:!mt-0"
       aria-label={sectionTitle}
     >
-      <div className="border-b pb-1">
+      <div className="border-b border-orange-300/50 pb-1">
         <h2 className="min-w-0 text-2xl font-semibold text-orange-300">
           {sectionTitle}
         </h2>

--- a/components/LearningsDisplay.tsx
+++ b/components/LearningsDisplay.tsx
@@ -30,7 +30,7 @@ export default function LearningsDisplay({
         section="learnings"
         locale={locale}
         title={title}
-        className="border-b pb-1 text-2xl font-semibold text-teal-300"
+        className="border-b border-teal-300/50 pb-1 text-2xl font-semibold text-teal-300"
       />
       <ul className="cv-section-simple-list cv-cq-link-list max-md:mt-6">
         {items.map((learning) => (

--- a/components/OfferTailoredShell.tsx
+++ b/components/OfferTailoredShell.tsx
@@ -118,7 +118,7 @@ export default function OfferTailoredShell({
             {/* Coordonnées : après Adéquation poste, même placement que le CV court. */}
             {headerContactStrip.email && (
               <section className="cv-mobile-section-mt print-preview:order-[30] print:order-[30] print:break-inside-avoid">
-                <div className="border-b pb-1">
+                <div className="border-b border-rose-300/50 pb-1">
                   <SectionHeadingAts
                     section="contact"
                     locale={lang}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -420,6 +420,14 @@ html {
     margin: 10mm 1mm;
   }
 
+  /* Anti-titre-orphelin : un titre ne reste jamais seul en bas de page. */
+  .cv-full-cv-print-root h2 {
+    break-after: avoid;
+  }
+  .cv-full-cv-print-root .border-b:has(> h2) {
+    break-after: avoid;
+  }
+
   /* ================================================================
    * === SHORT CV — ajustements print (A4 portrait ~794px) =========
    * Une seule zone pour tout le comportement print du CV court.


### PR DESCRIPTION
## Filet de section coloré
Chaque titre de section reçoit un `border-bottom` de **sa** couleur, en plus clair (`/50`) au lieu du gris neutre :
Profile bleu · Compétences teal · Adéquation orange · Coordonnées rose · Études violet · Projets bleu · Apprentissages teal · Loisirs orange · Expérience rose.
→ chaque section = **une** couleur (titre + filet + accent).

## Anti-titre-orphelin (print)
Règle `break-after: avoid` sur les titres (+ wrappers de titre) : un titre ne reste **jamais seul en bas de page** — il emmène le début de son contenu. Règle le « Projets » orphelin signalé, **sans saut de page forcé** ailleurs.

Vérifié via Playwright (écran + PDF 6 pages) : tous les filets colorés OK ; Études / Projets / Apprentissages / Loisirs gardent titre + contenu ensemble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)