### PR TITLE
feat: Solopreneur curé (EM-CDI) + âge rose + titre Compétences masqué

### DIFF
--- a/app/[lang]/domains.tsx
+++ b/app/[lang]/domains.tsx
@@ -25,7 +25,7 @@ export default async function domains({
           à l'écran ce titre est porté par la sidebar `skills.tsx` (donc pas de
           doublon) ; en PDF la sidebar est masquée, et ce titre donne aux ATS
           l'anchor « Skills » juste au-dessus des compétences (tags Agile/Dev/Ops). */}
-      <div className="mb-2 hidden border-b border-cv-section/50 pb-1 print-preview:block print:block">
+      <div className="mb-2 hidden border-b border-cv-section/50 pb-1">
         <SectionHeadingAts
           section="skills"
           locale={locale}

--- a/app/[lang]/skills.tsx
+++ b/app/[lang]/skills.tsx
@@ -31,7 +31,7 @@ export default async function skills({
         section="skills"
         locale={locale}
         title={data?.skillsTitle?.title}
-        className="border-b border-cv-section/50 pb-1 text-2xl font-semibold text-cv-section"
+        className="hidden border-b border-cv-section/50 pb-1 text-2xl font-semibold text-cv-section"
       />
       <div className="mt-4 flex flex-wrap gap-2">
         {data?.allSkillsModels?.map((skill: any) => (

--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -110,7 +110,7 @@ export default function HeaderContent({
           </p>
           {ageText ? (
             <p
-              className={`mt-1 text-base leading-snug text-gray-400 md:mt-2 md:text-xl ${
+              className={`mt-1 text-base leading-snug text-rose-300 md:mt-2 md:text-xl ${
                 compactPrint
                   ? 'print:mt-0 print:text-xs'
                   : 'print:mt-1 print:text-lg'

--- a/data/cv/locales/en.json
+++ b/data/cv/locales/en.json
@@ -103,19 +103,16 @@
       "location": "@home · home office",
       "roleName": "Solopreneur · side projects",
       "description": "",
-      "descriptionShort": "Building and shipping B2B and B2C digital products end to end—from ideation through production launch and operations.",
+      "descriptionShort": "Between assignments, I design and ship my own digital products end to end—a product R&D where I own both the engineering and the delivery.",
       "bullets": [
         {
-          "id": "job_solopreneur_en_b_multi",
-          "text": "multi.app — control softwares with midi, osc, webhooks by motion"
+          "id": "job_solopreneur_en_b_muti",
+          "text": "Muti — turns body motion into a MIDI / OSC / WebSocket controller.",
+          "link": "https://muti.app"
         },
         {
-          "id": "job_solopreneur_en_b_city",
-          "text": "City Guided — connected city guide."
-        },
-        {
-          "id": "job_solopreneur_en_b_next",
-          "text": "Up next: Shopify assistant, Livestreamz, Jober, Cop1, Realizator, Okascore, …"
+          "id": "job_solopreneur_en_b_livestreamz",
+          "text": "Livestreamz — turns a phone into a camera for reliable real-time streaming."
         }
       ]
     },

--- a/data/cv/locales/fr.json
+++ b/data/cv/locales/fr.json
@@ -107,19 +107,16 @@
       "location": "@home · maison",
       "roleName": "Solopreneur · projets personnels",
       "description": "",
-      "descriptionShort": "Conception et livraison de produits numériques B2B et B2C, de l’idéation à la mise en production et au run.",
+      "descriptionShort": "Entre deux missions, je conçois et livre mes propres produits numériques, de l’idéation au run — une R&D produit où je porte le tech et le pilotage.",
       "bullets": [
         {
-          "id": "job_solopreneur_fr_b_multi",
-          "text": "multi.app — Pilotage midi, osc, webhooks par le mouvement."
+          "id": "job_solopreneur_fr_b_muti",
+          "text": "Muti — transforme les mouvements du corps en contrôleur MIDI / OSC / WebSocket.",
+          "link": "https://muti.app"
         },
         {
-          "id": "job_solopreneur_fr_b_city",
-          "text": "City Guided — guide urbain connecté (github.com/elzinko/city-guided)."
-        },
-        {
-          "id": "job_solopreneur_fr_b_next",
-          "text": "À venir : assistant Shopify, Livestreamz, Jober, Cop1, Realizator, Okascore, …"
+          "id": "job_solopreneur_fr_b_livestreamz",
+          "text": "Livestreamz — transforme le téléphone en caméra pour du streaming temps réel fiable."
         }
       ]
     },


### PR DESCRIPTION
- **Solopreneur** : cadrage « R&D produit entre deux missions » + **2 phares** (Muti → lien muti.app, Livestreamz). Liste « À venir » + URL City Guided retirées (curation pour un profil Engineering Manager CDI). FR + EN. Section **Projets** inchangée (volontairement).
- **Âge** « 46 ans » en **rose** (`text-rose-300`), comme les Coordonnées.
- **Titre « Compétences » masqué** (sidebar écran + ancre print). Blocs Agile/Dev/Ops + pills conservés ; les mots-clés restent dans la couche texte pour les ATS.

Vérifié Playwright (écran + PDF). Build + 158/158 tests.