### PR TITLE
feat: page 1 tricolore (sections alignées sur les ancres d'en-tête)

### DIFF
--- a/app/[lang]/about.tsx
+++ b/app/[lang]/about.tsx
@@ -24,12 +24,12 @@ export default async function About({
       id="about"
       className="mb-1 mt-4 pb-1 print-preview:order-[10] print:order-[10] max-md:!mt-0"
     >
-      <div className="border-b border-cv-tag-text/50 pb-1">
+      <div className="border-b border-blue-400/50 pb-1">
         <SectionHeadingAts
           section="about"
           locale={locale}
           title={data?.about?.title}
-          className="min-w-0 text-2xl font-semibold text-cv-tag-text"
+          className="min-w-0 text-2xl font-semibold text-blue-400"
         />
       </div>
       <p className="mt-4 text-cv-body-muted">

--- a/components/ContactDisplay.tsx
+++ b/components/ContactDisplay.tsx
@@ -88,7 +88,7 @@ export default function ContactDisplay({
       const sizeToken = compact
         ? 'cv-contact-value-compact'
         : 'cv-contact-value';
-      const valueCls = `${sizeToken} text-rose-300`;
+      const valueCls = `${sizeToken} text-emerald-500`;
       const linkCls =
         'no-underline hover:underline hover:decoration-rose-300/50 hover:underline-offset-2';
       const mapsHref = ctx?.mapsHref ?? buildContactLocationHref();

--- a/components/Domain.tsx
+++ b/components/Domain.tsx
@@ -105,13 +105,13 @@ export default function Domain({
   const accent = titleAccent ?? DOMAIN_TITLE_ACCENT_DEFAULT;
 
   const titleTypo = compact
-    ? 'text-2xl font-semibold text-cv-section print:text-sm'
-    : 'text-2xl font-semibold text-cv-section';
+    ? 'text-2xl font-semibold text-blue-400 print:text-sm'
+    : 'text-2xl font-semibold text-blue-400';
 
   const titleBlock =
     accent === 'verticalBar' ? (
       <div
-        className={`flex items-stretch gap-1.5 text-cv-section ${
+        className={`flex items-stretch gap-1.5 text-blue-400 ${
           compact ? 'print:gap-1' : ''
         }`}
       >

--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -95,7 +95,7 @@ export default function HeaderContent({
             {name}
           </h1>
           <p
-            className={`mt-1 text-lg leading-snug text-cv-section md:mt-3 md:leading-normal ${
+            className={`mt-1 text-lg leading-snug text-amber-500 md:mt-3 md:leading-normal ${
               photoUrl ? 'md:text-2xl' : 'md:text-3xl'
             } ${
               compactPrint
@@ -110,7 +110,7 @@ export default function HeaderContent({
           </p>
           {ageText ? (
             <p
-              className={`mt-1 text-base leading-snug text-rose-300 md:mt-2 md:text-xl ${
+              className={`mt-1 text-base leading-snug text-emerald-500 md:mt-2 md:text-xl ${
                 compactPrint
                   ? 'print:mt-0 print:text-xs'
                   : 'print:mt-1 print:text-lg'

--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -59,7 +59,7 @@ export default function JobFitSection({
   if (variant === 'compact') {
     return (
       <section id="job-fit" className="mb-6" aria-label={sectionTitle}>
-        <h2 className="border-b border-orange-300/50 pb-1 text-2xl font-semibold text-orange-300">
+        <h2 className="border-b border-amber-500/50 pb-1 text-2xl font-semibold text-amber-500">
           {sectionTitle}
         </h2>
         <div className="cv-section-body-gap flex flex-wrap items-center gap-1.5 print:gap-1">
@@ -108,8 +108,8 @@ export default function JobFitSection({
       className="cv-mobile-section-mt print-preview:order-[25] print:order-[25] max-md:!mt-0"
       aria-label={sectionTitle}
     >
-      <div className="border-b border-orange-300/50 pb-1">
-        <h2 className="min-w-0 text-2xl font-semibold text-orange-300">
+      <div className="border-b border-amber-500/50 pb-1">
+        <h2 className="min-w-0 text-2xl font-semibold text-amber-500">
           {sectionTitle}
         </h2>
       </div>

--- a/components/OfferTailoredShell.tsx
+++ b/components/OfferTailoredShell.tsx
@@ -118,12 +118,12 @@ export default function OfferTailoredShell({
             {/* Coordonnées : après Adéquation poste, même placement que le CV court. */}
             {headerContactStrip.email && (
               <section className="cv-mobile-section-mt print-preview:order-[30] print:order-[30] print:break-inside-avoid">
-                <div className="border-b border-rose-300/50 pb-1">
+                <div className="border-b border-emerald-500/50 pb-1">
                   <SectionHeadingAts
                     section="contact"
                     locale={lang}
                     title={lang === 'fr' ? 'Coordonnées' : 'Contact'}
-                    className="min-w-0 text-2xl font-semibold text-rose-300"
+                    className="min-w-0 text-2xl font-semibold text-emerald-500"
                   />
                 </div>
                 <ContactDisplay

--- a/components/Pill.tsx
+++ b/components/Pill.tsx
@@ -66,7 +66,7 @@ export default function Pill({
     const truncCls = compact ? 'min-w-0 truncate' : 'min-w-0';
 
     const metricCls =
-      'text-[10px] font-normal tabular-nums text-orange-200/95 print:text-[9px] print:!text-orange-300 md:text-xs';
+      'text-[10px] font-normal tabular-nums text-amber-300/95 print:text-[9px] print:!text-amber-500 md:text-xs';
 
     return (
       <Tag className={classes} {...linkProps}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -365,9 +365,9 @@
   }
 
   .cv-pill-domain {
-    @apply rounded border border-teal-300/50 bg-teal-300/10 text-cv-section transition-colors;
-    @apply hover:border-teal-300 hover:bg-teal-300/20;
-    @apply print:!text-cv-section;
+    @apply rounded border border-blue-400/50 bg-blue-400/10 text-blue-400 transition-colors;
+    @apply hover:border-blue-300 hover:bg-blue-400/20;
+    @apply print:!text-blue-400;
   }
 
   /** Pastille « niveau » (Bac+5, Bac+3, équivalent EN) — pas le bloc entier. */
@@ -377,14 +377,14 @@
   }
 
   .cv-pill-match {
-    @apply rounded border border-orange-300/50 bg-orange-300/10 font-medium text-orange-300 transition-colors;
-    @apply hover:border-orange-300/70 hover:bg-orange-300/20;
-    @apply print:border-orange-300/60 print:!text-orange-300;
+    @apply rounded border border-amber-400/50 bg-amber-300/10 font-medium text-amber-500 transition-colors;
+    @apply hover:border-amber-400/70 hover:bg-amber-300/20;
+    @apply print:border-amber-400/60 print:!text-amber-500;
   }
 
   .cv-pill-match-borderless {
-    @apply rounded bg-orange-300/10 font-normal text-orange-300 transition-colors;
-    @apply print:bg-orange-300/10 print:!text-orange-300;
+    @apply rounded bg-amber-300/10 font-normal text-amber-500 transition-colors;
+    @apply print:bg-amber-300/10 print:!text-amber-500;
   }
 }
 
@@ -706,11 +706,14 @@ html {
   /* Coordonnées : forcer la couleur rose-300 en impression (WYSIWYG). */
   .cv-header-contact-strip,
   .cv-short-contact-rows {
-    color: #fda4af !important; /* rose-300 */
+    color: #10b981 !important; /* emerald-500 — section Coordonnées = vert */
   }
-  .cv-header-contact-strip a,
-  .cv-short-contact-rows a {
+  .cv-header-contact-strip a {
     color: #fda4af !important; /* rose-300 */
+    text-decoration: none !important;
+  }
+  .cv-short-contact-rows a {
+    color: #10b981 !important; /* emerald-500 */
     text-decoration: none !important;
   }
 


### PR DESCRIPTION
Système **3 couleurs** sur la page 1 — une section = une seule couleur (titre + filet + accents + pastilles + texte), chaque section reprenant la couleur de son ancre dans l'en-tête :

- 🔵 **Bleu** (= nom « Thomas Couderc ») : **Summary** + **Agile/Dev/Ops**
- 🟡 **Jaune/ambre** (= titre « Senior Fullstack Developer ») : **Adéquation poste**
- 🟢 **Vert** (= âge) : **Coordonnées** (titre + email/tél/ville)

En-tête rendu tricolore (nom bleu · titre ambre · âge vert). Le **reste** du CV garde ses couleurs.

Vérifié Playwright (PDF page 1). Build + lint OK.

> Suite (PR séparée) : Projets/Education en une ligne (desktop) comme Learnings + harmonisation des espacements mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)