### PR TITLE
feat: Projets + Education en une ligne (desktop) + espacement mobile homogène

### DIFF
--- a/app/[lang]/projects.tsx
+++ b/app/[lang]/projects.tsx
@@ -1,4 +1,3 @@
-import Project from '@/components/Project';
 import SectionHeadingAts from '@/components/SectionHeadingAts';
 import { getCvData } from '@/lib/cv-data';
 import type { CvMode } from '@/lib/cv-contract-text';
@@ -6,6 +5,7 @@ import {
   byEndThenStart,
   sortChronologicalDesc,
 } from '@/lib/sort-chronological';
+import { capitalizeFirstLetter } from '@/lib/capitalize-first';
 import { Locale } from 'i18n-config';
 import React from 'react';
 
@@ -39,26 +39,51 @@ export default async function projects({
       : 'mt-10 print:order-[100] print-preview:order-[100]';
 
   return (
-    <>
-      <section
-        id={sectionId === false ? undefined : sectionId}
-        data-cv-section="projects"
-        className={`cv-cq-section ${sectionClass}`}
-      >
-        <SectionHeadingAts
-          section="projects"
-          locale={locale}
-          title={data?.projectsTitle?.title ?? 'Projects'}
-          className="border-b border-cv-tag-text/50 pb-1 text-2xl font-semibold text-cv-tag-text"
-        />
-        <ul className="cv-section-simple-list cv-cq-project-list max-md:mt-6">
-          {projectsOrdered.map((project: any) => (
-            <li key={project.id}>
-              <Project project={project} />
+    <section
+      id={sectionId === false ? undefined : sectionId}
+      data-cv-section="projects"
+      className={`cv-cq-section ${sectionClass}`}
+    >
+      <SectionHeadingAts
+        section="projects"
+        locale={locale}
+        title={data?.projectsTitle?.title ?? 'Projects'}
+        className="border-b border-cv-tag-text/50 pb-1 text-2xl font-semibold text-cv-tag-text"
+      />
+      {/* Une ligne par projet : titre (lien coloré) — description inline (desktop),
+          masquée en colonne étroite (mobile). Même pattern que Learnings/Hobbies. */}
+      <ul className="cv-section-simple-list cv-cq-link-list max-md:mt-6">
+        {projectsOrdered.map((project: any) => {
+          const name =
+            (typeof project.title === 'string' && project.title.trim()) ||
+            (project.name ? capitalizeFirstLetter(project.name) : '');
+          const description =
+            typeof project.description === 'string'
+              ? project.description.trim()
+              : '';
+          return (
+            <li className="text-cv-tag-text" key={project.id}>
+              {project.link ? (
+                <a
+                  href={project.link}
+                  className="text-cv-tag-text underline-offset-2 hover:underline print:!text-cv-tag-text"
+                >
+                  {name}
+                </a>
+              ) : (
+                <span className="text-cv-tag-text print:!text-cv-tag-text">
+                  {name}
+                </span>
+              )}
+              {description ? (
+                <span className="cv-row-inline-desc ml-1 text-sm text-cv-body-muted">
+                  {'—'} {description}
+                </span>
+              ) : null}
             </li>
-          ))}
-        </ul>
-      </section>
-    </>
+          );
+        })}
+      </ul>
+    </section>
   );
 }

--- a/app/[lang]/studies.tsx
+++ b/app/[lang]/studies.tsx
@@ -8,12 +8,27 @@ import {
 import { Locale } from 'i18n-config';
 import React from 'react';
 
+function studyMetaLine(study: any): string {
+  return [study.location, study.establishment]
+    .filter((p: unknown) => Boolean(p && String(p).trim()))
+    .join(' / ');
+}
+
+function studyYear(study: any): string {
+  const end = study.endDate ? new Date(study.endDate).getFullYear() : null;
+  if (end) return `${end}`;
+  const start = study.startDate
+    ? new Date(study.startDate).getFullYear()
+    : null;
+  return start ? `${start}` : '';
+}
+
 export default async function studies({
   locale,
   condensed = false,
 }: {
   locale: Locale;
-  /** `true` : ligne unique titre/lieu/établissement. `false` : rendu classique. */
+  /** `true` : rendu compact (CV court). `false` : une ligne inline (CV complet). */
   condensed?: boolean;
 }) {
   const data: any = await getCvData(locale);
@@ -32,12 +47,31 @@ export default async function studies({
         title={data?.studiesTitle?.title}
         className="border-b border-purple-300/50 pb-1 text-2xl font-semibold text-purple-300"
       />
-      <ul className="cv-section-simple-list">
-        {studiesOrdered.map((study: any) => (
-          <li key={study.id}>
-            <Study study={study} condensed={condensed} />
-          </li>
-        ))}
+      {/* Une ligne par diplôme : intitulé — lieu / établissement, année (inline
+          desktop, masqué mobile). Même pattern que Learnings/Projets. */}
+      <ul className="cv-section-simple-list cv-cq-link-list">
+        {studiesOrdered.map((study: any) => {
+          if (condensed) {
+            return (
+              <li key={study.id}>
+                <Study study={study} condensed />
+              </li>
+            );
+          }
+          const meta = studyMetaLine(study);
+          const year = studyYear(study);
+          const tail = [meta, year].filter(Boolean).join(' · ');
+          return (
+            <li className="text-purple-300" key={study.id}>
+              <span className="text-purple-300">{study.name}</span>
+              {tail ? (
+                <span className="cv-row-inline-desc ml-1 text-sm text-cv-body-muted">
+                  {'—'} {tail}
+                </span>
+              ) : null}
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -120,6 +120,20 @@
   }
 
   /**
+   * Description inline générique (Projets, Education) — même comportement que
+   * Learnings/Hobbies : masquée en colonne étroite (mobile), inline en large
+   * (desktop ≥ 36rem). Garantit « une ligne » au desktop + espacement homogène.
+   */
+  .cv-cq-section .cv-row-inline-desc {
+    display: none;
+  }
+  @container (min-width: 36rem) {
+    .cv-cq-section .cv-row-inline-desc {
+      display: inline;
+    }
+  }
+
+  /**
    * Sections dont le rendu dépend de la largeur disponible (container queries) :
    * projets (titre / description / date), études (méta lieu), veille et loisirs (liste vs slashs).
    */


### PR DESCRIPTION
Aligne **Projets** et **Education** sur le pattern inline de **Learnings/Hobbies** : chaque entrée = **titre (lien coloré) — description inline**, inline en desktop (≥36rem), description masquée en colonne étroite (mobile).

- Règle CSS générique `.cv-row-inline-desc` (inline desktop / masquée mobile, container query 36rem).
- **Espacements mobile homogènes** : Education/Projets/Learnings partagent `cv-section-simple-list` (space-y-1) — Projets n'a plus de marge en trop.
- Projets : « titre — description » (date retirée, comme Learnings). Education : « intitulé — lieu / établissement · année ».

Vérifié Playwright : PDF (desktop large) une ligne ✓ ; mobile titres seuls + espacement uniforme ✓. Build + lint OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)