### PR TITLE
fix: jaune pastel (orange-300) au lieu de l'ambre ocre

### DIFF
--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -95,7 +95,7 @@ export default function HeaderContent({
             {name}
           </h1>
           <p
-            className={`mt-1 text-lg leading-snug text-amber-500 md:mt-3 md:leading-normal ${
+            className={`mt-1 text-lg leading-snug text-orange-300 md:mt-3 md:leading-normal ${
               photoUrl ? 'md:text-2xl' : 'md:text-3xl'
             } ${
               compactPrint

--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -59,7 +59,7 @@ export default function JobFitSection({
   if (variant === 'compact') {
     return (
       <section id="job-fit" className="mb-6" aria-label={sectionTitle}>
-        <h2 className="border-b border-amber-500/50 pb-1 text-2xl font-semibold text-amber-500">
+        <h2 className="border-b border-orange-300/50 pb-1 text-2xl font-semibold text-orange-300">
           {sectionTitle}
         </h2>
         <div className="cv-section-body-gap flex flex-wrap items-center gap-1.5 print:gap-1">
@@ -108,8 +108,8 @@ export default function JobFitSection({
       className="cv-mobile-section-mt print-preview:order-[25] print:order-[25] max-md:!mt-0"
       aria-label={sectionTitle}
     >
-      <div className="border-b border-amber-500/50 pb-1">
-        <h2 className="min-w-0 text-2xl font-semibold text-amber-500">
+      <div className="border-b border-orange-300/50 pb-1">
+        <h2 className="min-w-0 text-2xl font-semibold text-orange-300">
           {sectionTitle}
         </h2>
       </div>

--- a/components/Pill.tsx
+++ b/components/Pill.tsx
@@ -66,7 +66,7 @@ export default function Pill({
     const truncCls = compact ? 'min-w-0 truncate' : 'min-w-0';
 
     const metricCls =
-      'text-[10px] font-normal tabular-nums text-amber-300/95 print:text-[9px] print:!text-amber-500 md:text-xs';
+      'text-[10px] font-normal tabular-nums text-orange-200/95 print:text-[9px] print:!text-orange-300 md:text-xs';
 
     return (
       <Tag className={classes} {...linkProps}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -391,14 +391,14 @@
   }
 
   .cv-pill-match {
-    @apply rounded border border-amber-400/50 bg-amber-300/10 font-medium text-amber-500 transition-colors;
-    @apply hover:border-amber-400/70 hover:bg-amber-300/20;
-    @apply print:border-amber-400/60 print:!text-amber-500;
+    @apply rounded border border-orange-300/50 bg-orange-300/10 font-medium text-orange-300 transition-colors;
+    @apply hover:border-orange-300/70 hover:bg-orange-300/20;
+    @apply print:border-orange-300/60 print:!text-orange-300;
   }
 
   .cv-pill-match-borderless {
-    @apply rounded bg-amber-300/10 font-normal text-amber-500 transition-colors;
-    @apply print:bg-amber-300/10 print:!text-amber-500;
+    @apply rounded bg-orange-300/10 font-normal text-orange-300 transition-colors;
+    @apply print:bg-orange-300/10 print:!text-orange-300;
   }
 }
 


### PR DESCRIPTION
L'ambre (`amber-500`) du « jaune » tirait sur l'ocre. Retour à l'ancien **pastel orange-300** pour le slot jaune : titre « Senior Fullstack Developer », **Adéquation poste** (titre + filet + pastilles + métrique). Le bleu (nom/Summary/Domains) et le vert (âge/Coordonnées) restent. Mapping par section inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)