### PR TITLE
feat: en-tête mobile aligné à gauche + icônes colorées mobile + ids testables

### DIFF
--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -79,8 +79,9 @@ export default function HeaderContent({
 
         {/* Bloc droit : nom + rôle + âge + coordonnées, alignés à droite.
             `flex-1` → même largeur que le bloc photo (ou toute la largeur sans photo). */}
-        <div className="flex flex-1 flex-col items-end text-right">
+        <div className="flex flex-1 flex-col items-start text-left md:items-end md:text-right">
           <h1
+            data-cv-id="fullname"
             className={`font-extrabold leading-tight text-blue-400 ${
               compactPrint
                 ? 'text-3xl print:text-3xl print:leading-tight md:text-5xl md:leading-none lg:text-7xl'
@@ -95,6 +96,7 @@ export default function HeaderContent({
             {name}
           </h1>
           <p
+            data-cv-id="title"
             className={`mt-1 text-lg leading-snug text-orange-300 md:mt-3 md:leading-normal ${
               photoUrl ? 'md:text-2xl' : 'md:text-3xl'
             } ${
@@ -110,6 +112,7 @@ export default function HeaderContent({
           </p>
           {ageText ? (
             <p
+              data-cv-id="age"
               className={`mt-1 text-base leading-snug text-emerald-500 md:mt-2 md:text-xl ${
                 compactPrint
                   ? 'print:mt-0 print:text-xs'
@@ -126,9 +129,10 @@ export default function HeaderContent({
           ) : null}
         </div>
 
-        {/* Barre verticale décorative */}
+        {/* Barre verticale décorative — à GAUCHE en mobile (order-first), à droite
+            en desktop/print (md:order-none = ordre DOM, donc après le texte). */}
         <div
-          className="w-1 shrink-0 self-stretch rounded-full bg-gradient-to-b from-blue-400/40 to-teal-300/25 print:w-1 md:w-1.5"
+          className="order-first w-1 shrink-0 self-stretch rounded-full bg-gradient-to-b from-blue-400/40 to-teal-300/25 print:w-1 md:order-none md:w-1.5"
           aria-hidden
         />
       </div>

--- a/components/HeaderToolbar.tsx
+++ b/components/HeaderToolbar.tsx
@@ -413,6 +413,8 @@ export default function HeaderToolbar({
 
         <button
           type="button"
+          id="cv-menu-toggle"
+          data-cv-id="menu"
           data-testid="cv-mobile-menu-toggle"
           className="relative inline-flex h-[var(--cv-toolbar-btn)] w-[var(--cv-toolbar-btn)] shrink-0 items-center justify-center rounded-md border border-slate-400/40 bg-white text-slate-700 shadow-sm transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/60 focus-visible:ring-offset-2"
           aria-expanded={open}

--- a/lib/cv-header-toolbar.ts
+++ b/lib/cv-header-toolbar.ts
@@ -24,11 +24,16 @@ const iconShell = `inline-flex h-[var(--cv-toolbar-btn)] w-[var(--cv-toolbar-btn
 const iconHoverNeutral =
   'hover:border-slate-500/55 hover:bg-slate-50 hover:text-neutral-900';
 
+// Mobile : pas de survol → on applique la couleur « active » (de marque) PAR DÉFAUT
+// via `max-md:` (les icônes ne restent pas grises faute de hover).
+const iconMobileNeutral =
+  'max-md:border-slate-500/55 max-md:bg-slate-50 max-md:text-neutral-900';
+
 export const cvHeaderIconBtn = {
-  linkedin: `${iconShell} hover:border-[#0A66C2]/45 hover:bg-[#0A66C2]/8 hover:text-[#0A66C2]`,
-  github: `${iconShell} ${iconHoverNeutral}`,
-  malt: `${iconShell} group hover:border-slate-500/55 hover:bg-slate-50`,
-  print: `${iconShell} ${iconHoverNeutral}`,
+  linkedin: `${iconShell} hover:border-[#0A66C2]/45 hover:bg-[#0A66C2]/8 hover:text-[#0A66C2] max-md:border-[#0A66C2]/45 max-md:bg-[#0A66C2]/8 max-md:text-[#0A66C2]`,
+  github: `${iconShell} ${iconHoverNeutral} ${iconMobileNeutral}`,
+  malt: `${iconShell} group hover:border-slate-500/55 hover:bg-slate-50 max-md:border-slate-500/55 max-md:bg-slate-50`,
+  print: `${iconShell} ${iconHoverNeutral} ${iconMobileNeutral}`,
 } as const;
 
 /** Bascule version CV — même hauteur que les icônes. */


### PR DESCRIPTION
- **En-tête mobile aligné à gauche** (items-start/text-left), **inchangé en desktop** (md:items-end/text-right). **Barre verticale à gauche** en mobile (order-first / md:order-none).
- **Icônes toolbar colorées par défaut en mobile** (variantes max-md:) — pas de survol sur mobile : LinkedIn bleu, GitHub/print sombres, Malt rouge.
- **Identifiants testables** : data-cv-id sur fullname / title / age ; id `cv-menu-toggle` + data-cv-id `menu` sur le bouton menu. (Les sections ont déjà #id + data-cv-section.)

Vérifié Playwright mobile (sans/avec photo + menu ouvert). Desktop inchangé (md: overrides). Build + lint OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)