### PR TITLE
fix: vert Coordonnées plus pastel (emerald-400) + section homogène

### DIFF
--- a/components/CompactCvLayout.tsx
+++ b/components/CompactCvLayout.tsx
@@ -179,7 +179,7 @@ export default function CompactCvLayout({
       <section id="domains" className="mt-2">
         {/* Ancre « Compétences / Skills » réservée à l'impression (anchor ATS au
             dessus des compétences) ; masquée à l'écran. */}
-        <div className="mb-2 hidden border-b pb-1 print:block print-preview:block">
+        <div className="mb-2 hidden border-b pb-1 print-preview:block print:block">
           <SectionHeadingAts
             section="skills"
             locale={lang}
@@ -202,7 +202,7 @@ export default function CompactCvLayout({
       {children}
 
       {/* Mobile-only : Adéquation poste + Coordonnées, hors grille, avant Expérience. */}
-      <div className="mt-6 space-y-6 md:hidden print:hidden">
+      <div className="mt-6 space-y-6 print:hidden md:hidden">
         <Suspense fallback={null}>
           <JobFitSection
             lang={lang}
@@ -212,7 +212,7 @@ export default function CompactCvLayout({
           />
         </Suspense>
         <section>
-          <div className="border-b pb-1">
+          <div className="border-b border-emerald-400/50 pb-1">
             <SectionHeadingAts
               section="contact"
               locale={lang}
@@ -220,7 +220,7 @@ export default function CompactCvLayout({
                 data.titles.contact ||
                 (lang === 'fr' ? 'Coordonnées' : 'Contact')
               }
-              className="min-w-0 text-2xl font-semibold text-rose-300"
+              className="min-w-0 text-2xl font-semibold text-emerald-400"
             />
           </div>
           <ContactDisplay
@@ -237,10 +237,10 @@ export default function CompactCvLayout({
       <div className="cv-page-split mt-8">
         <div
           id="left"
-          className="order-last flex w-full min-w-0 flex-col md:order-first md:col-span-1 print:order-first print:col-span-1"
+          className="order-last flex w-full min-w-0 flex-col print:order-first print:col-span-1 md:order-first md:col-span-1"
         >
           {/* Adéquation poste : masqué en mobile (dupliqué hors grille). */}
-          <div className="hidden md:block print:block">
+          <div className="hidden print:block md:block">
             <Suspense fallback={null}>
               <JobFitSection
                 lang={lang}
@@ -254,9 +254,9 @@ export default function CompactCvLayout({
           {/* Coordonnées (label : valeur) dans la colonne gauche — masqué en mobile (dupliqué hors grille). */}
           <section
             id="cv-short-contact"
-            className="mb-6 hidden md:block print:block"
+            className="mb-6 hidden print:block md:block"
           >
-            <div className="border-b pb-1">
+            <div className="border-b border-emerald-400/50 pb-1">
               <SectionHeadingAts
                 section="contact"
                 locale={lang}
@@ -264,7 +264,7 @@ export default function CompactCvLayout({
                   data.titles.contact ||
                   (lang === 'fr' ? 'Coordonnées' : 'Contact')
                 }
-                className="min-w-0 text-2xl font-semibold text-rose-300"
+                className="min-w-0 text-2xl font-semibold text-emerald-400"
               />
             </div>
             <ContactDisplay
@@ -330,7 +330,7 @@ export default function CompactCvLayout({
 
         <div
           id="main"
-          className="w-full min-w-0 md:col-span-2 print:col-span-2"
+          className="w-full min-w-0 print:col-span-2 md:col-span-2"
         >
           {/* Experience - Reusing JobDisplay component */}
           <section>

--- a/components/ContactDisplay.tsx
+++ b/components/ContactDisplay.tsx
@@ -81,16 +81,16 @@ export default function ContactDisplay({
   const ctx = useContactLocation();
 
   if (cvShortInlineRows) {
-    // Mode sans labels : valeurs seules, alignées à gauche, couleur rose-300.
+    // Mode sans labels : valeurs seules, alignées à gauche, couleur verte (emerald-400).
     // Structure identique aux autres listes simples (Études, Projets) :
     // <ul cv-section-simple-list> → <li> → <a> (pas de wrapper div).
     if (!showLabels) {
       const sizeToken = compact
         ? 'cv-contact-value-compact'
         : 'cv-contact-value';
-      const valueCls = `${sizeToken} text-emerald-500`;
+      const valueCls = `${sizeToken} text-emerald-400`;
       const linkCls =
-        'no-underline hover:underline hover:decoration-rose-300/50 hover:underline-offset-2';
+        'no-underline hover:underline hover:decoration-emerald-300/50 hover:underline-offset-2';
       const mapsHref = ctx?.mapsHref ?? buildContactLocationHref();
       const isDirections = ctx?.isDirections ?? false;
       const loc = ctx?.locale ?? locale;

--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -113,7 +113,7 @@ export default function HeaderContent({
           {ageText ? (
             <p
               data-cv-id="age"
-              className={`mt-1 text-base leading-snug text-emerald-500 md:mt-2 md:text-xl ${
+              className={`mt-1 text-base leading-snug text-emerald-400 md:mt-2 md:text-xl ${
                 compactPrint
                   ? 'print:mt-0 print:text-xs'
                   : 'print:mt-1 print:text-lg'

--- a/components/HeaderDesktopContactStrip.tsx
+++ b/components/HeaderDesktopContactStrip.tsx
@@ -43,13 +43,13 @@ export default function HeaderDesktopContactStrip({
 
   return (
     <div
-      className={`cv-header-contact-strip mt-2 flex w-full flex-col ${alignItems} gap-0.5 ${textAlign} text-sm leading-snug text-rose-300 print:mt-0 print:flex md:mt-0 md:pb-1 md:text-sm md:leading-snug ${printAlignItems} print:gap-0.5 print:pb-0.5 ${printTextAlign} print:text-sm print:leading-snug print:text-rose-300`}
+      className={`cv-header-contact-strip mt-2 flex w-full flex-col ${alignItems} gap-0.5 ${textAlign} text-sm leading-snug text-emerald-400 print:mt-0 print:flex md:mt-0 md:pb-1 md:text-sm md:leading-snug ${printAlignItems} print:gap-0.5 print:pb-0.5 ${printTextAlign} print:text-sm print:leading-snug print:text-emerald-400`}
       aria-label="Contact"
     >
       {email ? (
         <a
           href={`mailto:${email}`}
-          className="break-all text-inherit no-underline hover:underline hover:decoration-rose-300/50 hover:underline-offset-2"
+          className="break-all text-inherit no-underline hover:underline hover:decoration-emerald-300/50 hover:underline-offset-2"
         >
           {email}
         </a>
@@ -57,7 +57,7 @@ export default function HeaderDesktopContactStrip({
       {phone ? (
         <a
           href={`tel:${phone.replace(/\s/g, '')}`}
-          className="text-inherit no-underline hover:underline hover:decoration-rose-300/50 hover:underline-offset-2"
+          className="text-inherit no-underline hover:underline hover:decoration-emerald-300/50 hover:underline-offset-2"
         >
           {phone}
         </a>

--- a/components/OfferTailoredShell.tsx
+++ b/components/OfferTailoredShell.tsx
@@ -118,12 +118,12 @@ export default function OfferTailoredShell({
             {/* Coordonnées : après Adéquation poste, même placement que le CV court. */}
             {headerContactStrip.email && (
               <section className="cv-mobile-section-mt print-preview:order-[30] print:order-[30] print:break-inside-avoid">
-                <div className="border-b border-emerald-500/50 pb-1">
+                <div className="border-b border-emerald-400/50 pb-1">
                   <SectionHeadingAts
                     section="contact"
                     locale={lang}
                     title={lang === 'fr' ? 'Coordonnées' : 'Contact'}
-                    className="min-w-0 text-2xl font-semibold text-emerald-500"
+                    className="min-w-0 text-2xl font-semibold text-emerald-400"
                   />
                 </div>
                 <ContactDisplay

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -717,17 +717,17 @@ html {
     color: inherit !important;
   }
 
-  /* Coordonnées : forcer la couleur rose-300 en impression (WYSIWYG). */
+  /* Coordonnées : forcer le vert pastel en impression (WYSIWYG). */
   .cv-header-contact-strip,
   .cv-short-contact-rows {
-    color: #10b981 !important; /* emerald-500 — section Coordonnées = vert */
+    color: #34d399 !important; /* emerald-400 — section Coordonnées = vert pastel */
   }
   .cv-header-contact-strip a {
-    color: #fda4af !important; /* rose-300 */
+    color: #34d399 !important; /* emerald-400 */
     text-decoration: none !important;
   }
   .cv-short-contact-rows a {
-    color: #10b981 !important; /* emerald-500 */
+    color: #34d399 !important; /* emerald-400 */
     text-decoration: none !important;
   }
 


### PR DESCRIPTION
## Pourquoi
Le vert de la section **Coordonnées / âge** (`emerald-500` `#10b981`) était trop intense. On le ramène dans le même registre pastel que le **bleu** (`blue-400`, nom) et l'**orange** (`orange-300`, titre) de la page 1.

## Ce qui change
- `emerald-500` → **`emerald-400`** (`#34d399`) partout où le vert est utilisé.
- Toute la section Coordonnées est désormais **homogène** (une section = une seule couleur) : titres, bordures bas, et valeurs — qui mélangeaient encore `rose-300` (titres `CompactCvLayout` + bandeau en-tête) et vert (valeurs).

| Fichier | Détail |
|---|---|
| `HeaderContent` | âge `emerald-500` → `emerald-400` |
| `OfferTailoredShell` | titre + bordure Coordonnées → `emerald-400` |
| `CompactCvLayout` | 2 titres `rose-300` → `emerald-400`, bordures bas colorées (`border-emerald-400/50`) |
| `HeaderDesktopContactStrip` | bandeau contact `rose-300` → `emerald-400` |
| `ContactDisplay` | valeurs `emerald-500` → `emerald-400` |
| `globals.css` | `.cv-*-contact-rows` `#10b981` → `#34d399` |

## Vérif
- `npm run lint` ✔ · `npm run build` ✔
- Rendu `/fr/short` : titre **et** valeurs Coordonnées = `rgb(52,211,153)` (emerald-400), cohérents ; trio en-tête bleu / orange / vert dans le même registre pastel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)