### PR TITLE
fix: en-tête (nom/poste/âge) accentué intermédiaire + Profil en bleu

### DIFF
--- a/components/CompactCvLayout.tsx
+++ b/components/CompactCvLayout.tsx
@@ -164,12 +164,12 @@ export default function CompactCvLayout({
     <div className="cv-layout-short">
       {/* About - Full width section (same style as full CV) */}
       <section id="cv-short-about" className="cv-short-about mb-1 mt-4 pb-1">
-        <div className="border-b pb-1">
+        <div className="border-b border-blue-400/50 pb-1">
           <SectionHeadingAts
             section="about"
             locale={lang}
             title={t.about}
-            className="min-w-0 text-2xl font-semibold text-cv-section"
+            className="min-w-0 text-2xl font-semibold text-blue-400"
           />
         </div>
         <p className="mt-4 text-cv-body-muted">{data.about}</p>

--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -82,7 +82,7 @@ export default function HeaderContent({
         <div className="flex flex-1 flex-col items-start text-left md:items-end md:text-right">
           <h1
             data-cv-id="fullname"
-            className={`font-extrabold leading-tight text-blue-400 ${
+            className={`font-extrabold leading-tight text-[#4e94f8] ${
               compactPrint
                 ? 'text-3xl print:text-3xl print:leading-tight md:text-5xl md:leading-none lg:text-7xl'
                 : photoUrl
@@ -97,7 +97,7 @@ export default function HeaderContent({
           </h1>
           <p
             data-cv-id="title"
-            className={`mt-1 text-lg leading-snug text-orange-300 md:mt-3 md:leading-normal ${
+            className={`mt-1 text-lg leading-snug text-[#fca658] md:mt-3 md:leading-normal ${
               photoUrl ? 'md:text-2xl' : 'md:text-3xl'
             } ${
               compactPrint
@@ -113,7 +113,7 @@ export default function HeaderContent({
           {ageText ? (
             <p
               data-cv-id="age"
-              className={`mt-1 text-base leading-snug text-emerald-400 md:mt-2 md:text-xl ${
+              className={`mt-1 text-base leading-snug text-[#22c68d] md:mt-2 md:text-xl ${
                 compactPrint
                   ? 'print:mt-0 print:text-xs'
                   : 'print:mt-1 print:text-lg'


### PR DESCRIPTION
## Pourquoi
Le contenu du CV reste en **pastel** (validé tel quel). On accentue **uniquement les 3 ancres de l'en-tête** (nom, poste, âge), à un niveau **intermédiaire** entre le pastel actuel et le niveau « accentué » précédemment proposé (jugé un poil trop fort).

Et le titre **Profil** du CV court était en turquoise (`cv-section`) — il repasse en **bleu**, cohérent avec le nom, les Domaines (Agile/Dev/Ops déjà bleus) et le CV complet.

## Valeurs
| Élément | Avant | Après |
|---|---|---|
| Nom | `blue-400` `#60a5fa` | `#4e94f8` |
| Poste | `orange-300` `#fdba74` | `#fca658` |
| Âge | `emerald-400` `#34d399` | `#22c68d` |
| Titre Profil (CV court) | `cv-section` turquoise | `text-blue-400` + `border-blue-400/50` |

Le reste de la palette (Adéquation orange, Coordonnées vert, contenu) est **inchangé**.

## Vérif (`/fr/short`, rendu réel)
- nom `rgb(78,148,248)` · poste `rgb(252,166,88)` · âge `rgb(34,198,141)` ✔
- Profil `rgb(96,165,250)` = blue-400 ✔ · Coordonnées `rgb(52,211,153)` = emerald-400 (inchangé) ✔
- `npm run lint` ✔ · `npm run build` ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)