### PR TITLE
fix: filets de section discrets + cohérents (composant unique) + ATS hors écran

### DIFF
--- a/app/[lang]/about.tsx
+++ b/app/[lang]/about.tsx
@@ -24,14 +24,13 @@ export default async function About({
       id="about"
       className="mb-1 mt-4 pb-1 print-preview:order-[10] print:order-[10] max-md:!mt-0"
     >
-      <div className="border-b border-blue-400/50 pb-1">
-        <SectionHeadingAts
-          section="about"
-          locale={locale}
-          title={data?.about?.title}
-          className="min-w-0 text-2xl font-semibold text-blue-400"
-        />
-      </div>
+      <SectionHeadingAts
+        section="about"
+        locale={locale}
+        title={data?.about?.title}
+        accent="blue"
+        className="min-w-0"
+      />
       <p className="mt-4 text-cv-body-muted">
         {resolveAboutText(data?.about, contract, mode)}
       </p>

--- a/app/[lang]/contact.tsx
+++ b/app/[lang]/contact.tsx
@@ -41,7 +41,7 @@ export default async function Contact({
         section="contact"
         locale={locale}
         title={contactData.title || 'Contact'}
-        className="border-b pb-1 text-2xl font-semibold text-cv-jobs"
+        accent="pink"
       />
       <ContactDisplay contact={contactData} locale={locale} />
     </section>

--- a/app/[lang]/domains.tsx
+++ b/app/[lang]/domains.tsx
@@ -25,12 +25,13 @@ export default async function domains({
           à l'écran ce titre est porté par la sidebar `skills.tsx` (donc pas de
           doublon) ; en PDF la sidebar est masquée, et ce titre donne aux ATS
           l'anchor « Skills » juste au-dessus des compétences (tags Agile/Dev/Ops). */}
-      <div className="mb-2 hidden border-b border-cv-section/50 pb-1">
+      <div className="mb-2 hidden">
         <SectionHeadingAts
           section="skills"
           locale={locale}
           title={data?.skillsTitle?.title}
-          className="min-w-0 text-2xl font-semibold text-cv-section"
+          accent="section"
+          className="min-w-0"
         />
       </div>
       <div className="cv-domains-grid">

--- a/app/[lang]/projects.tsx
+++ b/app/[lang]/projects.tsx
@@ -48,7 +48,7 @@ export default async function projects({
         section="projects"
         locale={locale}
         title={data?.projectsTitle?.title ?? 'Projects'}
-        className="border-b border-cv-tag-text/50 pb-1 text-2xl font-semibold text-cv-tag-text"
+        accent="tag"
       />
       {/* Une ligne par projet : titre (lien coloré) — description inline (desktop),
           masquée en colonne étroite (mobile). Même pattern que Learnings/Hobbies. */}

--- a/app/[lang]/skills.tsx
+++ b/app/[lang]/skills.tsx
@@ -31,7 +31,8 @@ export default async function skills({
         section="skills"
         locale={locale}
         title={data?.skillsTitle?.title}
-        className="hidden border-b border-cv-section/50 pb-1 text-2xl font-semibold text-cv-section"
+        accent="section"
+        className="hidden"
       />
       <div className="mt-4 flex flex-wrap gap-2">
         {data?.allSkillsModels?.map((skill: any) => (

--- a/app/[lang]/studies.tsx
+++ b/app/[lang]/studies.tsx
@@ -45,7 +45,7 @@ export default async function studies({
         section="studies"
         locale={locale}
         title={data?.studiesTitle?.title}
-        className="border-b border-purple-300/50 pb-1 text-2xl font-semibold text-purple-300"
+        accent="purple"
       />
       {/* Une ligne par diplôme : intitulé — lieu / établissement, année (inline
           desktop, masqué mobile). Même pattern que Learnings/Projets. */}

--- a/components/CompactCvLayout.tsx
+++ b/components/CompactCvLayout.tsx
@@ -164,14 +164,13 @@ export default function CompactCvLayout({
     <div className="cv-layout-short">
       {/* About - Full width section (same style as full CV) */}
       <section id="cv-short-about" className="cv-short-about mb-1 mt-4 pb-1">
-        <div className="border-b border-blue-400/50 pb-1">
-          <SectionHeadingAts
-            section="about"
-            locale={lang}
-            title={t.about}
-            className="min-w-0 text-2xl font-semibold text-blue-400"
-          />
-        </div>
+        <SectionHeadingAts
+          section="about"
+          locale={lang}
+          title={t.about}
+          accent="blue"
+          className="min-w-0"
+        />
         <p className="mt-4 text-cv-body-muted">{data.about}</p>
       </section>
 
@@ -179,12 +178,13 @@ export default function CompactCvLayout({
       <section id="domains" className="mt-2">
         {/* Ancre « Compétences / Skills » réservée à l'impression (anchor ATS au
             dessus des compétences) ; masquée à l'écran. */}
-        <div className="mb-2 hidden border-b pb-1 print-preview:block print:block">
+        <div className="mb-2 hidden">
           <SectionHeadingAts
             section="skills"
             locale={lang}
             title={t.skills}
-            className="min-w-0 text-2xl font-semibold text-cv-tag-text"
+            accent="tag"
+            className="min-w-0"
           />
         </div>
         <div className="cv-domains-grid">
@@ -212,17 +212,15 @@ export default function CompactCvLayout({
           />
         </Suspense>
         <section>
-          <div className="border-b border-emerald-400/50 pb-1">
-            <SectionHeadingAts
-              section="contact"
-              locale={lang}
-              title={
-                data.titles.contact ||
-                (lang === 'fr' ? 'Coordonnées' : 'Contact')
-              }
-              className="min-w-0 text-2xl font-semibold text-emerald-400"
-            />
-          </div>
+          <SectionHeadingAts
+            section="contact"
+            locale={lang}
+            title={
+              data.titles.contact || (lang === 'fr' ? 'Coordonnées' : 'Contact')
+            }
+            accent="emerald"
+            className="min-w-0"
+          />
           <ContactDisplay
             contact={data.contact}
             cvShortInlineRows
@@ -256,17 +254,16 @@ export default function CompactCvLayout({
             id="cv-short-contact"
             className="mb-6 hidden print:block md:block"
           >
-            <div className="border-b border-emerald-400/50 pb-1">
-              <SectionHeadingAts
-                section="contact"
-                locale={lang}
-                title={
-                  data.titles.contact ||
-                  (lang === 'fr' ? 'Coordonnées' : 'Contact')
-                }
-                className="min-w-0 text-2xl font-semibold text-emerald-400"
-              />
-            </div>
+            <SectionHeadingAts
+              section="contact"
+              locale={lang}
+              title={
+                data.titles.contact ||
+                (lang === 'fr' ? 'Coordonnées' : 'Contact')
+              }
+              accent="emerald"
+              className="min-w-0"
+            />
             <ContactDisplay
               contact={data.contact}
               cvShortInlineRows
@@ -296,7 +293,7 @@ export default function CompactCvLayout({
               section="studies"
               locale={lang}
               title={t.education}
-              className="border-b pb-1 text-2xl font-semibold text-purple-300"
+              accent="purple"
             />
             <ul className="cv-section-simple-list">
               {data.studies.map((study) => (
@@ -316,7 +313,7 @@ export default function CompactCvLayout({
               section="projects"
               locale={lang}
               title={data.projectsTitle}
-              className="border-b pb-1 text-2xl font-semibold text-cv-tag-text"
+              accent="tag"
             />
             <ul className="cv-section-simple-list">
               {data.projects.map((project: any) => (
@@ -338,7 +335,7 @@ export default function CompactCvLayout({
               section="jobs"
               locale={lang}
               title={t.experience}
-              className="border-b pb-1 text-2xl font-semibold text-cv-jobs"
+              accent="pink"
             />
 
             {jobSections ? (
@@ -359,7 +356,7 @@ export default function CompactCvLayout({
                 {otherJobs.length > 0 ? (
                   /* ── « Autres expériences » : reste compressé (client · rôle · période) ── */
                   <div className="mt-6">
-                    <h3 className="border-b pb-1 text-base font-semibold text-cv-jobs print:text-[10px]">
+                    <h3 className="border-b border-cv-jobs/25 pb-1 text-base font-semibold text-cv-jobs print:text-[10px]">
                       {t.otherExperience}
                     </h3>
                     <ul className="mt-2 space-y-1">

--- a/components/ExperienceSection.tsx
+++ b/components/ExperienceSection.tsx
@@ -41,12 +41,14 @@ export default function ExperienceSection({
 
   return (
     <>
-      <div className="flex items-end justify-between gap-2 border-b border-cv-jobs/50 pb-1 print:break-after-avoid">
+      <div className="flex items-end justify-between gap-2 border-b border-cv-jobs/25 pb-1 print:break-after-avoid">
         <SectionHeadingAts
           section={section}
           locale={locale}
           title={title}
-          className="min-w-0 text-2xl font-semibold text-cv-jobs"
+          accent="pink"
+          withBorder={false}
+          className="min-w-0"
         />
         {canToggleDetails ? (
           <button

--- a/components/HobbiesDisplay.tsx
+++ b/components/HobbiesDisplay.tsx
@@ -29,7 +29,7 @@ export default function HobbiesDisplay({
         section="hobbies"
         locale={locale}
         title={title}
-        className="border-b border-orange-300/50 pb-1 text-2xl font-semibold text-orange-300"
+        accent="orange"
       />
       <ul className="cv-section-simple-list cv-cq-link-list max-md:mt-6">
         {items.map((hobby) => (

--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -15,6 +15,7 @@ import { truncateClientsForDisplay } from '@/lib/match-clients-display';
 import type { Locale } from 'i18n-config';
 import { useMemo } from 'react';
 import Pill from '@/components/Pill';
+import SectionHeadingAts from '@/components/SectionHeadingAts';
 import { slugifyClient } from '@/lib/slug';
 
 interface JobFitSectionProps {
@@ -59,9 +60,7 @@ export default function JobFitSection({
   if (variant === 'compact') {
     return (
       <section id="job-fit" className="mb-6" aria-label={sectionTitle}>
-        <h2 className="border-b border-orange-300/50 pb-1 text-2xl font-semibold text-orange-300">
-          {sectionTitle}
-        </h2>
+        <SectionHeadingAts accent="orange" locale={lang} title={sectionTitle} />
         <div className="cv-section-body-gap flex flex-wrap items-center gap-1.5 print:gap-1">
           {showEducationLevel && (
             <Pill color="match" compact>
@@ -108,11 +107,12 @@ export default function JobFitSection({
       className="cv-mobile-section-mt print-preview:order-[25] print:order-[25] max-md:!mt-0"
       aria-label={sectionTitle}
     >
-      <div className="border-b border-orange-300/50 pb-1">
-        <h2 className="min-w-0 text-2xl font-semibold text-orange-300">
-          {sectionTitle}
-        </h2>
-      </div>
+      <SectionHeadingAts
+        accent="orange"
+        locale={lang}
+        title={sectionTitle}
+        className="min-w-0"
+      />
 
       <ul className="mt-3 space-y-2.5 print:mt-2 print:space-y-1.5 md:mt-4 md:space-y-3">
         {showEducationLevel && (

--- a/components/LearningsDisplay.tsx
+++ b/components/LearningsDisplay.tsx
@@ -30,7 +30,7 @@ export default function LearningsDisplay({
         section="learnings"
         locale={locale}
         title={title}
-        className="border-b border-teal-300/50 pb-1 text-2xl font-semibold text-teal-300"
+        accent="teal"
       />
       <ul className="cv-section-simple-list cv-cq-link-list max-md:mt-6">
         {items.map((learning) => (

--- a/components/OfferTailoredShell.tsx
+++ b/components/OfferTailoredShell.tsx
@@ -118,14 +118,13 @@ export default function OfferTailoredShell({
             {/* Coordonnées : après Adéquation poste, même placement que le CV court. */}
             {headerContactStrip.email && (
               <section className="cv-mobile-section-mt print-preview:order-[30] print:order-[30] print:break-inside-avoid">
-                <div className="border-b border-emerald-400/50 pb-1">
-                  <SectionHeadingAts
-                    section="contact"
-                    locale={lang}
-                    title={lang === 'fr' ? 'Coordonnées' : 'Contact'}
-                    className="min-w-0 text-2xl font-semibold text-emerald-400"
-                  />
-                </div>
+                <SectionHeadingAts
+                  section="contact"
+                  locale={lang}
+                  title={lang === 'fr' ? 'Coordonnées' : 'Contact'}
+                  accent="emerald"
+                  className="min-w-0"
+                />
                 <ContactDisplay
                   contact={{
                     emailTitle: 'Email',

--- a/components/SectionHeadingAts.tsx
+++ b/components/SectionHeadingAts.tsx
@@ -2,45 +2,91 @@ import React from 'react';
 import type { Locale } from 'i18n-config';
 import { atsSectionLabel, type AtsSectionKey } from '@/lib/ats-labels';
 
+/**
+ * Accent d'une section : pilote À LA FOIS la couleur du titre ET la couleur du
+ * filet (toujours atténué, discret). Source unique de cohérence — aucune section
+ * ne doit redéfinir son filet à la main (c'est ce qui faisait dériver Études /
+ * Projets / Expériences vers un gris incohérent).
+ */
+export type SectionAccent =
+  | 'blue' // Profil / Résumé, Domaines
+  | 'emerald' // Coordonnées
+  | 'orange' // Adéquation, Loisirs
+  | 'purple' // Études
+  | 'pink' // Expériences (cv-jobs)
+  | 'tag' // Projets, Compétences (cv-tag-text)
+  | 'teal' // Apprentissages
+  | 'section'; // legacy cv-section (turquoise)
+
+/**
+ * Atténuation unique du filet : `/25` au lieu de `/50` → trait discret, même
+ * teinte que le titre. Changer cette valeur ici la change pour TOUT le CV.
+ * (Classes littérales obligatoires pour le purge Tailwind — pas d'interpolation.)
+ */
+const ACCENT_CLASSES: Record<SectionAccent, { text: string; border: string }> =
+  {
+    blue: { text: 'text-blue-400', border: 'border-blue-400/25' },
+    emerald: { text: 'text-emerald-400', border: 'border-emerald-400/25' },
+    orange: { text: 'text-orange-300', border: 'border-orange-300/25' },
+    purple: { text: 'text-purple-300', border: 'border-purple-300/25' },
+    pink: { text: 'text-cv-jobs', border: 'border-cv-jobs/25' },
+    tag: { text: 'text-cv-tag-text', border: 'border-cv-tag-text/25' },
+    teal: { text: 'text-teal-300', border: 'border-teal-300/25' },
+    section: { text: 'text-cv-section', border: 'border-cv-section/25' },
+  };
+
 interface SectionHeadingAtsProps {
-  /** Clé de section pour retrouver le libellé ATS canonique. */
-  section: AtsSectionKey;
+  /** Clé ATS pour le libellé anglais (PDF). Omis = pas de libellé ATS (ex. Adéquation). */
+  section?: AtsSectionKey;
   locale: Locale;
   /** Titre localisé affiché en principal (français sur `/fr`). */
   title?: string | null;
-  /** Classes du `<h2>` existant (couleur de section, bordure, modifs print…). */
+  /** Couleur de section : titre + filet atténué. Cohérence garantie par le composant. */
+  accent: SectionAccent;
+  /**
+   * `false` : le composant ne rend PAS son filet (le parent le porte). Réservé aux
+   * en-têtes composés (ex. Expériences avec bouton « afficher les détails »).
+   */
+  withBorder?: boolean;
+  /** Classes additionnelles (min-w-0, hidden, marges, tailles print…). Pas la couleur ni le filet. */
   className?: string;
 }
 
 /**
- * Titre de section bilingue « discret ».
+ * Titre de section canonique du CV.
  *
- * Sur `/en` (ou quand aucun libellé ATS n'est pertinent), rend EXACTEMENT
- * `<h2 className={className}>{title}</h2>` — donc strictement identique à
- * l'ancien markup : aucune régression visuelle.
- *
- * Sur `/fr`, ajoute l'équivalent anglais canonique reconnu par les ATS, en
- * petit, muet, aligné à droite sur la même ligne (coût vertical nul → pas de
- * page supplémentaire). C'est un nœud texte réel (présent dans la couche texte
- * du PDF, contrairement à un `::before`/`aria-label`) et SANS letter-spacing,
- * qui ferait éclater le mot lettre par lettre à l'extraction (« E D U C… »).
+ * - Couleur du titre + filet atténué pilotés par `accent` (source unique).
+ * - Sur `/en` (ou sans `section`), rend simplement `<h2>{title}</h2>` stylé.
+ * - Sur `/fr`, ajoute l'équivalent ATS anglais canonique reconnu par les parseurs,
+ *   **uniquement à l'impression** (`hidden print:inline`) : présent dans la couche
+ *   texte du PDF pour les ATS, mais SANS doublon visible à l'écran pour un humain.
+ *   Texte réel sans letter-spacing (sinon « E D U C… » à l'extraction).
  */
 export default function SectionHeadingAts({
   section,
   locale,
   title,
+  accent,
+  withBorder = true,
   className,
 }: SectionHeadingAtsProps) {
-  const ats = atsSectionLabel(section, locale, title);
+  const { text, border } = ACCENT_CLASSES[accent];
+  const base = `${
+    withBorder ? `border-b ${border} ` : ''
+  }pb-1 text-2xl font-semibold ${text}`;
+  const ats = section ? atsSectionLabel(section, locale, title) : null;
+
   if (!ats) {
-    return <h2 className={className}>{title}</h2>;
+    return <h2 className={`${base} ${className ?? ''}`}>{title}</h2>;
   }
   return (
     <h2
-      className={`${className ?? ''} flex items-baseline justify-between gap-3`}
+      className={`${base} ${
+        className ?? ''
+      } flex items-baseline justify-between gap-3`}
     >
       <span className="min-w-0">{title}</span>
-      <span className="shrink-0 whitespace-nowrap text-[0.5em] font-normal opacity-60">
+      <span className="hidden shrink-0 whitespace-nowrap text-[0.5em] font-normal opacity-60 print-preview:inline print:inline">
         {ats}
       </span>
     </h2>


### PR DESCRIPTION
Passe UI/UX globale sur les titres de section du CV en ligne (`/fr/short` + `/fr`).

## Le vrai problème : ce n'était pas un composant
`SectionHeadingAts` existait mais ne **possédait pas** son filet — chaque section le redéclarait à la main (`<div className="border-b border-X/50">` ou inline). Résultat : Études / Projets / Expériences avaient dérivé vers un **filet gris** pendant que les autres étaient colorés.

## Fix : un composant canonique
`SectionHeadingAts` possède désormais **couleur du titre + filet** via une prop unique `accent`. Plus aucune dérive possible.

| Point demandé | Avant | Après |
|---|---|---|
| Filets trop marqués | `border-X/50` | **`/25`** (discret, même teinte que le titre) |
| Études / Projets / Expériences | filet **gris** | filet **coloré** (couleur du titre) atténué |
| Doublon « Summary / Contact… » à l'écran | visible | **masqué à l'écran**, conservé en PDF (parsing ATS) |
| « Compétences » en PDF | visible (print) | **masqué** aussi en PDF |

## Vérif (rendu réel, URL fournie)
- Écran : filets `rgba(.., 0.25)` colorés sur **toutes** les sections (Études purple, Projets blue, Expérience pink incluses) ; **aucun** libellé ATS visible.
- Print/PDF : libellés ATS discrets de retour (Summary, Contact, Education, Projects, Work Experience), **pas** de titre « Compétences ».
- `npm run lint` ✔ · `npm run build` ✔ (tous les call sites migrés vers `accent`).

## Note ATS
Les libellés anglais restent dans le **PDF** (c'est leur raison d'être : mapping ATS). Si tu préfères un PDF 100% épuré, on peut aussi les y retirer (au prix du mapping ATS) — dis-le.

🤖 Generated with [Claude Code](https://claude.com/claude-code)