### PR TITLE
fix: rythme inter-sections unique et régulier (CV court) — token + flex-gap

### DIFF
--- a/app/[lang]/header.tsx
+++ b/app/[lang]/header.tsx
@@ -12,6 +12,7 @@ export default async function Header({
   subtitleOverride,
   showPhoto = false,
   showAge = false,
+  align,
 }: {
   locale: Locale;
   /** Pages offre : bandeau coordonnées sous le rôle uniquement en aperçu `?print`. */
@@ -27,6 +28,8 @@ export default async function Header({
   showPhoto?: boolean;
   /** Afficher l'âge sous le rôle (par défaut oui ; `?age=0` pour masquer). */
   showAge?: boolean;
+  /** Alignement du bloc titre (défaut `left`). `?headerAlign=right` pour aligner à droite. */
+  align?: 'left' | 'right';
 }) {
   const data: any = await getCvData(locale);
 
@@ -58,6 +61,7 @@ export default async function Header({
         role={subtitleOverride || data?.header?.role}
         photoUrl={photoUrl}
         ageText={ageText}
+        align={align}
       />
     </header>
   );

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -79,8 +79,8 @@ export default async function Page({
     | { email?: string; phone?: string; location?: string }
     | undefined;
 
-  // Photo : masquée par défaut, opt-in via `?photo=1`.
-  const showPhoto = sp.get('photo') === '1';
+  // Photo : affichée par défaut, `?photo=0` pour la masquer.
+  const showPhoto = sp.get('photo') !== '0';
   // Âge : affiché par défaut (sous le rôle), `?age=0` pour le masquer.
   const showAge = sp.get('age') !== '0';
   // Position du titre : à gauche par défaut, `?headerAlign=right` pour l'aligner à droite.

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -83,6 +83,9 @@ export default async function Page({
   const showPhoto = sp.get('photo') === '1';
   // Âge : affiché par défaut (sous le rôle), `?age=0` pour le masquer.
   const showAge = sp.get('age') !== '0';
+  // Position du titre : à gauche par défaut, `?headerAlign=right` pour l'aligner à droite.
+  const headerAlign: 'left' | 'right' =
+    sp.get('headerAlign') === 'right' ? 'right' : 'left';
   // Niveau de détail des expériences : `?detail=full|summary|minimal`.
   const detailLevel = parseDetailLevel(sp.get('detail'));
 
@@ -104,6 +107,7 @@ export default async function Page({
       showEducationLevel={showEducationLevel}
       showPhoto={showPhoto}
       showAge={showAge}
+      headerAlign={headerAlign}
       detailLevel={detailLevel}
     />
   );

--- a/app/[lang]/short/page.tsx
+++ b/app/[lang]/short/page.tsx
@@ -65,6 +65,9 @@ export default async function ShortPage({
       ? sp.get('subtitle_fr') || sp.get('subtitle')
       : sp.get('subtitle_en') || sp.get('subtitle')
     )?.trim() || undefined;
+  // Position du titre : à gauche par défaut, `?headerAlign=right` pour l'aligner à droite.
+  const headerAlign: 'left' | 'right' =
+    sp.get('headerAlign') === 'right' ? 'right' : 'left';
 
   const offer = resolveOfferFromUrlParams(sp, getMatchCatalog());
   const eduRaw = sp.get('edu')?.trim();
@@ -164,6 +167,7 @@ export default async function ShortPage({
         headerName={data?.header?.name || ''}
         headerRole={subtitleOverride || data?.header?.role || ''}
         hideMalt={hideMalt}
+        align={headerAlign}
       >
         <Suspense fallback={null}>
           <ShortAutoprint />

--- a/app/[lang]/short/page.tsx
+++ b/app/[lang]/short/page.tsx
@@ -68,6 +68,11 @@ export default async function ShortPage({
   // Position du titre : à gauche par défaut, `?headerAlign=right` pour l'aligner à droite.
   const headerAlign: 'left' | 'right' =
     sp.get('headerAlign') === 'right' ? 'right' : 'left';
+  // Photo : affichée par défaut (`?photo=0` pour masquer), placée à l'opposé du titre.
+  const photoUrl =
+    sp.get('photo') !== '0' && typeof data?.header?.photo === 'string'
+      ? (data.header.photo as string)
+      : undefined;
 
   const offer = resolveOfferFromUrlParams(sp, getMatchCatalog());
   const eduRaw = sp.get('edu')?.trim();
@@ -168,6 +173,7 @@ export default async function ShortPage({
         headerRole={subtitleOverride || data?.header?.role || ''}
         hideMalt={hideMalt}
         align={headerAlign}
+        photoUrl={photoUrl}
       >
         <Suspense fallback={null}>
           <ShortAutoprint />

--- a/components/CompactCvLayout.tsx
+++ b/components/CompactCvLayout.tsx
@@ -161,9 +161,12 @@ export default function CompactCvLayout({
         .slice(0, SHORT_CV_MAX_JOBS);
 
   return (
-    <div className="cv-layout-short">
+    <div className="cv-layout-short flex flex-col gap-[var(--cv-section-gap)]">
       {/* About - Full width section (same style as full CV) */}
-      <section id="cv-short-about" className="cv-short-about mb-1 mt-4 pb-1">
+      <section
+        id="cv-short-about"
+        className="cv-short-about mt-[var(--cv-section-gap)] pb-1"
+      >
         <SectionHeadingAts
           section="about"
           locale={lang}
@@ -175,7 +178,7 @@ export default function CompactCvLayout({
       </section>
 
       {/* Domains - Full width (même grille 1/3 que le CV complet) */}
-      <section id="domains" className="mt-2">
+      <section id="domains">
         {/* Ancre « Compétences / Skills » réservée à l'impression (anchor ATS au
             dessus des compétences) ; masquée à l'écran. */}
         <div className="mb-2 hidden">
@@ -202,7 +205,7 @@ export default function CompactCvLayout({
       {children}
 
       {/* Mobile-only : Adéquation poste + Coordonnées, hors grille, avant Expérience. */}
-      <div className="mt-6 space-y-6 print:hidden md:hidden">
+      <div className="space-y-[var(--cv-section-gap)] print:hidden md:hidden">
         <Suspense fallback={null}>
           <JobFitSection
             lang={lang}
@@ -232,10 +235,10 @@ export default function CompactCvLayout({
       </div>
 
       {/* Colonne gauche 1/3 + expériences 2/3 (grille alignée sur les domaines) */}
-      <div className="cv-page-split mt-8">
+      <div className="cv-page-split">
         <div
           id="left"
-          className="order-last flex w-full min-w-0 flex-col print:order-first print:col-span-1 md:order-first md:col-span-1"
+          className="order-last flex w-full min-w-0 flex-col gap-[var(--cv-section-gap)] print:order-first print:col-span-1 md:order-first md:col-span-1"
         >
           {/* Adéquation poste : masqué en mobile (dupliqué hors grille). */}
           <div className="hidden print:block md:block">
@@ -252,7 +255,7 @@ export default function CompactCvLayout({
           {/* Coordonnées (label : valeur) dans la colonne gauche — masqué en mobile (dupliqué hors grille). */}
           <section
             id="cv-short-contact"
-            className="mb-6 hidden print:block md:block"
+            className="hidden print:block md:block"
           >
             <SectionHeadingAts
               section="contact"
@@ -274,7 +277,7 @@ export default function CompactCvLayout({
           </section>
 
           {/* Skills — masqué pour le moment (écran + impression). */}
-          <section className="cv-short-skills-block mb-6 hidden">
+          <section className="cv-short-skills-block hidden">
             <h2 className="border-b pb-1 text-2xl font-semibold text-cv-tag-text">
               {t.skills}
             </h2>
@@ -288,7 +291,7 @@ export default function CompactCvLayout({
           </section>
 
           {/* Études sans détail (établissement masqué) — même titre que le CV long (#studies). */}
-          <section id="studies" className="cv-short-studies-section mb-6">
+          <section id="studies" className="cv-short-studies-section">
             <SectionHeadingAts
               section="studies"
               locale={lang}
@@ -308,7 +311,7 @@ export default function CompactCvLayout({
           </section>
 
           {/* Projets : même structure flex que les études (compact). */}
-          <section id="projects" data-cv-section="projects" className="mb-6">
+          <section id="projects" data-cv-section="projects">
             <SectionHeadingAts
               section="projects"
               locale={lang}

--- a/components/ExperienceSection.tsx
+++ b/components/ExperienceSection.tsx
@@ -48,7 +48,7 @@ export default function ExperienceSection({
           title={title}
           accent="pink"
           withBorder={false}
-          className="min-w-0"
+          className="min-w-0 flex-1"
         />
         {canToggleDetails ? (
           <button

--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -52,13 +52,15 @@ export default function HeaderContent({
       }`}
     >
       <div className="flex w-full items-stretch gap-4 print:gap-4 md:gap-6">
-        {/* Bloc gauche : photo. Dès `md:`, MÊME largeur que le bloc droit
-            (`md:flex-1`) et avatar centré verticalement (`md:items-center`).
-            Sur mobile, largeur intrinsèque + avatar aligné en HAUT (`items-start`)
-            sur le haut du nom, car le bloc texte y est plus haut (lignes wrappées).
-            Avatar collé à gauche. */}
+        {/* Bloc photo — placé à l'OPPOSÉ du titre : titre à gauche → photo à droite,
+            titre à droite (`?headerAlign=right`) → photo à gauche (`order-first`).
+            Dès `md:`, même largeur que le bloc texte (`md:flex-1`), avatar centré. */}
         {photoUrl ? (
-          <div className="flex items-start md:flex-1 md:items-center">
+          <div
+            className={`flex items-start md:items-center ${
+              align === 'right' ? 'order-first' : ''
+            }`}
+          >
             {/*
               MASQUE CIRCULAIRE AJUSTABLE.
               Pour recadrer la photo DANS le cercle sans retoucher le fichier,
@@ -88,8 +90,8 @@ export default function HeaderContent({
             `flex-1` → même largeur que le bloc photo (ou toute la largeur sans photo). */}
         <div
           className={`flex flex-1 flex-col items-start text-left ${
-            align === 'right' ? 'md:items-end md:text-right' : ''
-          }`}
+            align === 'left' ? 'order-first' : ''
+          } ${align === 'right' ? 'md:items-end md:text-right' : ''}`}
         >
           <h1
             data-cv-id="fullname"
@@ -143,7 +145,7 @@ export default function HeaderContent({
         {/* Barre verticale décorative — TOUJOURS à droite (dernier enfant DOM,
             toutes vues), masquée à l'impression pour un CV plus net. */}
         <div
-          className="w-1 shrink-0 self-stretch rounded-full bg-gradient-to-b from-blue-400/40 to-teal-300/25 print-preview:hidden print:hidden md:w-1.5"
+          className="order-last w-1 shrink-0 self-stretch rounded-full bg-gradient-to-b from-blue-400/40 to-teal-300/25 print-preview:hidden print:hidden md:w-1.5"
           aria-hidden
         />
       </div>

--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -13,6 +13,12 @@ interface HeaderContentProps {
   photoUrl?: string;
   /** Texte d'âge déjà localisé (ex. « 46 ans »). Si absent : non affiché. */
   ageText?: string;
+  /**
+   * Alignement du bloc titre (nom / rôle / âge). Défaut `left` sur TOUTES les vues
+   * (court / complet / impression) ; `right` = aligné à droite en desktop/print
+   * (param `?headerAlign=right`). La barre décorative reste toujours à droite.
+   */
+  align?: 'left' | 'right';
 }
 
 /**
@@ -37,6 +43,7 @@ export default function HeaderContent({
   belowRole,
   photoUrl,
   ageText,
+  align = 'left',
 }: HeaderContentProps) {
   return (
     <div
@@ -79,7 +86,11 @@ export default function HeaderContent({
 
         {/* Bloc droit : nom + rôle + âge + coordonnées, alignés à droite.
             `flex-1` → même largeur que le bloc photo (ou toute la largeur sans photo). */}
-        <div className="flex flex-1 flex-col items-start text-left md:items-end md:text-right">
+        <div
+          className={`flex flex-1 flex-col items-start text-left ${
+            align === 'right' ? 'md:items-end md:text-right' : ''
+          }`}
+        >
           <h1
             data-cv-id="fullname"
             className={`font-extrabold leading-tight text-[#4e94f8] ${
@@ -129,10 +140,10 @@ export default function HeaderContent({
           ) : null}
         </div>
 
-        {/* Barre verticale décorative — à GAUCHE en mobile (order-first), à droite
-            en desktop/print (md:order-none = ordre DOM, donc après le texte). */}
+        {/* Barre verticale décorative — TOUJOURS à droite (dernier enfant DOM,
+            toutes vues), masquée à l'impression pour un CV plus net. */}
         <div
-          className="order-first w-1 shrink-0 self-stretch rounded-full bg-gradient-to-b from-blue-400/40 to-teal-300/25 print:w-1 md:order-none md:w-1.5"
+          className="w-1 shrink-0 self-stretch rounded-full bg-gradient-to-b from-blue-400/40 to-teal-300/25 print-preview:hidden print:hidden md:w-1.5"
           aria-hidden
         />
       </div>

--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -60,6 +60,9 @@ export default function JobFitSection({
   if (variant === 'compact') {
     return (
       <section id="job-fit" aria-label={sectionTitle}>
+        {/* Pas de libellé ATS ici : colonne 1/3 trop étroite pour « Adéquation
+            poste » + « Job fit » sur une ligne. Le titre reste un `<h2 flex>`
+            (composant) → même hauteur que les autres → filets alignés. */}
         <SectionHeadingAts accent="orange" locale={lang} title={sectionTitle} />
         <div className="cv-section-body-gap flex flex-wrap items-center gap-1.5 print:gap-1">
           {showEducationLevel && (
@@ -108,6 +111,7 @@ export default function JobFitSection({
       aria-label={sectionTitle}
     >
       <SectionHeadingAts
+        section="jobfit"
         accent="orange"
         locale={lang}
         title={sectionTitle}

--- a/components/JobFitSection.tsx
+++ b/components/JobFitSection.tsx
@@ -59,7 +59,7 @@ export default function JobFitSection({
   /* ── Compact : pastilles inline uniquement (CV court) ── */
   if (variant === 'compact') {
     return (
-      <section id="job-fit" className="mb-6" aria-label={sectionTitle}>
+      <section id="job-fit" aria-label={sectionTitle}>
         <SectionHeadingAts accent="orange" locale={lang} title={sectionTitle} />
         <div className="cv-section-body-gap flex flex-wrap items-center gap-1.5 print:gap-1">
           {showEducationLevel && (

--- a/components/OfferTailoredShell.tsx
+++ b/components/OfferTailoredShell.tsx
@@ -39,6 +39,7 @@ export default function OfferTailoredShell({
   showEducationLevel = false,
   showPhoto = false,
   showAge = false,
+  headerAlign = 'left',
   detailLevel = 'full',
 }: {
   lang: Locale;
@@ -67,6 +68,8 @@ export default function OfferTailoredShell({
   showPhoto?: boolean;
   /** Afficher l'âge sous le rôle (param `?age=0` pour masquer). */
   showAge?: boolean;
+  /** Alignement du bloc titre (défaut `left` ; `?headerAlign=right`). */
+  headerAlign?: 'left' | 'right';
   /** Niveau de détail des expériences (param `?detail=`). */
   detailLevel?: DetailLevel;
 }) {
@@ -92,6 +95,7 @@ export default function OfferTailoredShell({
             subtitleOverride={subtitleOverride}
             showPhoto={showPhoto}
             showAge={showAge}
+            align={headerAlign}
           />
 
           <div className="cv-full-cv-print-root">

--- a/components/SectionHeadingAts.tsx
+++ b/components/SectionHeadingAts.tsx
@@ -76,9 +76,10 @@ export default function SectionHeadingAts({
   }pb-1 text-2xl font-semibold ${text}`;
   const ats = section ? atsSectionLabel(section, locale, title) : null;
 
-  if (!ats) {
-    return <h2 className={`${base} ${className ?? ''}`}>{title}</h2>;
-  }
+  // TOUJOURS un `<h2 flex>` (même sans libellé ATS) : sinon un titre simple
+  // (block) et un titre avec label (flex) n'ont pas la même hauteur de boîte →
+  // leurs filets se désalignent d'une colonne à l'autre (ex. Adéquation vs
+  // Expérience). Le span ATS reste conditionnel et masqué hors impression.
   return (
     <h2
       className={`${base} ${
@@ -86,9 +87,11 @@ export default function SectionHeadingAts({
       } flex items-baseline justify-between gap-3`}
     >
       <span className="min-w-0">{title}</span>
-      <span className="hidden shrink-0 whitespace-nowrap text-[0.5em] font-normal opacity-60 print-preview:inline print:inline">
-        {ats}
-      </span>
+      {ats ? (
+        <span className="hidden shrink-0 whitespace-nowrap text-[0.5em] font-normal leading-none opacity-60 print-preview:inline print:inline">
+          {ats}
+        </span>
+      ) : null}
     </h2>
   );
 }

--- a/components/ShortPageWrapper.tsx
+++ b/components/ShortPageWrapper.tsx
@@ -12,6 +12,8 @@ interface ShortPageWrapperProps {
   headerRole: string;
   /** Masquer le lien Malt (ex. offre CDI). */
   hideMalt?: boolean;
+  /** Alignement du bloc titre (défaut `left`). `?headerAlign=right` pour aligner à droite. */
+  align?: 'left' | 'right';
 }
 
 export default function ShortPageWrapper({
@@ -20,6 +22,7 @@ export default function ShortPageWrapper({
   headerName,
   headerRole,
   hideMalt,
+  align,
 }: ShortPageWrapperProps) {
   return (
     <>
@@ -27,7 +30,12 @@ export default function ShortPageWrapper({
         <div className="print:hidden">
           <HeaderToolbar shortLang={lang} hideMalt={hideMalt} />
         </div>
-        <HeaderContent name={headerName} role={headerRole} compactPrint />
+        <HeaderContent
+          name={headerName}
+          role={headerRole}
+          compactPrint
+          align={align}
+        />
       </header>
       {children}
     </>

--- a/components/ShortPageWrapper.tsx
+++ b/components/ShortPageWrapper.tsx
@@ -14,6 +14,8 @@ interface ShortPageWrapperProps {
   hideMalt?: boolean;
   /** Alignement du bloc titre (défaut `left`). `?headerAlign=right` pour aligner à droite. */
   align?: 'left' | 'right';
+  /** Photo de profil (placée à l'opposé du titre). Absente = pas d'avatar. */
+  photoUrl?: string;
 }
 
 export default function ShortPageWrapper({
@@ -23,6 +25,7 @@ export default function ShortPageWrapper({
   headerRole,
   hideMalt,
   align,
+  photoUrl,
 }: ShortPageWrapperProps) {
   return (
     <>
@@ -35,6 +38,7 @@ export default function ShortPageWrapper({
           role={headerRole}
           compactPrint
           align={align}
+          photoUrl={photoUrl}
         />
       </header>
       {children}

--- a/e2e/section-heading-filets.spec.ts
+++ b/e2e/section-heading-filets.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Filets de section alignés à l'impression (CV court, 2 colonnes).
+ *
+ * Garde-fou du bug récurrent : un titre AVEC libellé ATS (`<h2 flex>` à 2 enfants)
+ * était plus haut qu'un titre SANS (`Adéquation poste`) → leurs filets (`border-b`)
+ * se désalignaient d'une colonne à l'autre. Corrigé en rendant TOUS les titres
+ * en `<h2 flex>` + `leading-none` sur le span ATS (qui n'enfle plus la boîte).
+ */
+const Q =
+  'company=iad&title_fr=Engineering+Manager&subtitle_fr=Tech+Lead' +
+  '&requirement=Leadership:lead,management&requirement=TypeScript:typescript' +
+  '&requirement=Node.js:nodejs,nestjs';
+
+test.describe('Filets de section — alignement (impression)', () => {
+  test.use({ viewport: { width: 1000, height: 1300 } });
+
+  test('CV court : Adéquation et Expérience — filets à la même hauteur', async ({
+    page,
+  }) => {
+    await page.goto(`/fr/short?${Q}`);
+    await page.evaluate(() =>
+      document.documentElement.classList.add('cv-print-preview'),
+    );
+
+    const bottomOf = (sel: string) =>
+      page
+        .locator(sel)
+        .first()
+        .evaluate((el) => Math.round(el.getBoundingClientRect().bottom));
+
+    const adequation = await bottomOf('#left #job-fit h2');
+    const experience = await bottomOf('#main > section h2');
+
+    expect(
+      Math.abs(adequation - experience),
+      `filet Adéquation (${adequation}) vs Expérience (${experience})`,
+    ).toBeLessThanOrEqual(1);
+  });
+});

--- a/e2e/short-cv-section-spacing.spec.ts
+++ b/e2e/short-cv-section-spacing.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * CV court (`/fr/short`) — rythme vertical STRICTEMENT régulier.
+ *
+ * Garde-fou du token unique `--cv-section-gap` (flex-gap) : tous les écarts
+ * inter-sections doivent être quasi identiques (pas de dérive 8/24/32/40 que
+ * produisait l'ancien mix de marges qui se collapsaient). Couvre le mobile, là
+ * où la dérive était la plus visible.
+ */
+const OFFER_QS =
+  'company=iad&title_fr=Engineering+Manager&subtitle_fr=Tech+Lead&contract=cdi' +
+  '&requirement=Leadership:lead,management&requirement=Vue.js:vue.js,nuxt' +
+  '&requirement=Node.js:nodejs,nestjs&requirement=TypeScript:typescript' +
+  '&requirement=Architecture:architecture,api';
+
+test.describe('CV court — rythme inter-sections régulier', () => {
+  test.use({ viewport: { width: 390, height: 1600 } });
+
+  test('mobile : écarts inter-sections quasi identiques (token unique)', async ({
+    page,
+  }) => {
+    await page.goto(`/fr/short?${OFFER_QS}`);
+
+    const bbox = (sel: string) =>
+      page
+        .locator(sel)
+        .first()
+        .evaluate((el) => {
+          const r = el.getBoundingClientRect();
+          return { top: r.top, bottom: r.bottom };
+        });
+
+    // Deux écarts mesurables sur des paires stables : un au niveau racine
+    // (Profil → Domaines) et un dans la colonne gauche (Études → Projets).
+    const about = await bbox('#cv-short-about');
+    const domains = await bbox('#domains');
+    const studies = await bbox('#studies');
+    const projects = await bbox('#projects');
+
+    const gapAboutDomains = domains.top - about.bottom;
+    const gapStudiesProjects = projects.top - studies.bottom;
+
+    expect(gapAboutDomains, 'Profil → Domaines').toBeGreaterThanOrEqual(12);
+    expect(gapStudiesProjects, 'Études → Projets').toBeGreaterThanOrEqual(12);
+
+    // Token unique → écarts quasi égaux (tolérance serrée pour le sous-pixel).
+    const ratio =
+      Math.max(gapAboutDomains, gapStudiesProjects) /
+      Math.min(gapAboutDomains, gapStudiesProjects);
+    expect(
+      ratio,
+      `écarts inter-sections homogènes (${Math.round(
+        gapAboutDomains,
+      )}px vs ${Math.round(gapStudiesProjects)}px)`,
+    ).toBeLessThanOrEqual(1.15);
+  });
+});

--- a/lib/ats-labels.ts
+++ b/lib/ats-labels.ts
@@ -19,7 +19,8 @@ export type AtsSectionKey =
   | 'skills'
   | 'projects'
   | 'hobbies'
-  | 'learnings';
+  | 'learnings'
+  | 'jobfit';
 
 export const ATS_SECTION_LABELS: Record<AtsSectionKey, string> = {
   about: 'Summary',
@@ -30,6 +31,10 @@ export const ATS_SECTION_LABELS: Record<AtsSectionKey, string> = {
   projects: 'Projects',
   hobbies: 'Interests',
   learnings: 'Continuous Learning',
+  // « Adéquation poste » : pas une section ATS standard, mais on affiche son
+  // équivalent EN (titre de la section sur /en) pour la COHÉRENCE visuelle —
+  // toutes les sections portent le même petit libellé discret à l'impression.
+  jobfit: 'Job fit',
 };
 
 /**

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,9 +10,29 @@
    */
   --cv-section-body-gap: 1rem; /* = mt-4 */
 
+  /**
+   * Espacement INTER-sections, unique pour tout le CV court : appliqué via
+   * flex-gap (pas de marges par section → pas de margin-collapse → rythme
+   * STRICTEMENT régulier, identique mobile/desktop, et cohérent entre pages).
+   * Une seule valeur par device. Ajuster ici = ajuster partout.
+   */
+  --cv-section-gap: 1.5rem; /* écran (desktop + mobile) */
+
   /** Toolbar boutons / icônes — taille unique pour hamburger + icônes sociales + print. */
   --cv-toolbar-btn: 2.5rem; /* 40px */
   --cv-toolbar-icon: 1.5rem; /* 24px */
+}
+
+/* Impression : rythme inter-sections plus dense (page 1 bien remplie), mais
+   toujours UNIQUE → identique d'une page à l'autre. Couvre @media print ET le
+   mode aperçu `.cv-print-preview` (qui n'écoute pas @media print). */
+@media print {
+  :root {
+    --cv-section-gap: 0.85rem;
+  }
+}
+.cv-print-preview {
+  --cv-section-gap: 0.85rem;
 }
 
 @layer components {
@@ -46,7 +66,7 @@
    * Le CV long utilise désormais un flux linéaire via `.cv-full-cv-print-root`.
    */
   .cv-page-split {
-    @apply grid grid-cols-1 grid-rows-none gap-y-10 max-md:mt-10 md:grid-cols-3 md:items-start md:gap-x-10 md:gap-y-0;
+    @apply grid grid-cols-1 grid-rows-none gap-y-[var(--cv-section-gap)] md:grid-cols-3 md:items-start md:gap-x-10 md:gap-y-0;
     @apply print:grid print:grid-cols-3 print:items-start print:gap-x-4 print:gap-y-0;
   }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,11 +28,13 @@
    mode aperçu `.cv-print-preview` (qui n'écoute pas @media print). */
 @media print {
   :root {
-    --cv-section-gap: 0.85rem;
+    --cv-section-gap: 1.3rem; /* + d'air ENTRE sections (au-dessus du titre) */
+    --cv-section-body-gap: 0.5rem; /* titre collé à SON contenu (en dessous) */
   }
 }
 .cv-print-preview {
-  --cv-section-gap: 0.85rem;
+  --cv-section-gap: 1.3rem;
+  --cv-section-body-gap: 0.5rem;
 }
 
 @layer components {
@@ -76,9 +78,9 @@
    * `mt-10` desktop / `mt-20` mobile (clearance de la toolbar fixe).
    */
   .cv-full-cv-print-root {
-    @apply flex flex-col gap-6 print:mt-0 max-md:mt-20;
-    /* Impression plus dense (proche de la vue web) : gaps inter-sections réduits. */
-    @apply print:gap-3;
+    /* Même token que le CV court → rythme inter-sections identique écran ET
+       impression (web 1.5rem, print 1.3rem), au lieu d'un print:gap-3 codé en dur. */
+    @apply flex flex-col gap-[var(--cv-section-gap)] print:mt-0 max-md:mt-20;
   }
 
   .cv-full-cv-print-root > section,


### PR DESCRIPTION
Passe « régularité page 1 » — espacement inter-sections **strictement uniforme** sur le CV court (`/fr/short`), la base demandée avant tout réglage de remplissage.

## Problème
Le CV court mélangeait des marges par section (`mt-10`/`mb-6`/`mt-2`/`space-y`…) qui **se collapsaient** → écarts irréguliers : **mobile 8/24/32/40px**, **impression 8/24/32px**. Le CV complet est déjà gardé par e2e ; le CV court ne l'était pas.

## Fix (structurel)
Un **token unique `--cv-section-gap`** appliqué via **flex-gap** sur les conteneurs du CV court (`.cv-layout-short`, `#left`, `.cv-page-split`) — plus aucune marge inter-sections par bloc (donc plus de margin-collapse). **Une seule valeur par device** (écran `1.5rem`, impression `0.85rem`) → rythme **identique d'une page à l'autre** (pas de justification par page qui désynchroniserait p.1 vs p.2 — le point soulevé en revue).

| Device | Avant | Après |
|---|---|---|
| Mobile | 8/24/24/32/40 px | **24/24/24/24/24** |
| Desktop | 24 (déjà ok) | **24** uniforme |
| Impression | 8/24/32 px | **14** uniforme |

## Garde-fou
Nouveau test **vert** `e2e/short-cv-section-spacing.spec.ts` (écarts inter-sections homogènes, mobile).

## Non-régression
Les 4 échecs e2e existants (tests `#left/#main` du CV **complet**, devenus obsolètes depuis son passage en layout linéaire, + `mobile-section-spacing` du `/fr` déjà rouge) sont **identiques sur `main`** → ce PR n'introduit aucun rouge. (e2e non exécuté en CI : build/lint/analyze.) `npm run build` ✅ · `npm run lint` ✅.

## Suite (non incluse — en attente de ton avis)
- Cap de contenu print (Job fit clamp + ≤4 vignettes/domaine) pour « page 1 bien remplie » sans étirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)