### PR TITLE
fix(cv): harmoniser les tailles du CV court (Contact/Études/Projets à 10px)

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -534,8 +534,14 @@ html {
 
   /* Densification typographique pour tenir sur 1 page A4 : tout le corps de
      texte (Profil, domaines, Expérience) partage `.cv-job-description` → même
-     taille partout, densifiée ici à l'impression. */
-  .cv-short-page .cv-job-description {
+     taille partout, densifiée ici à l'impression. La colonne secondaire
+     (Coordonnées, Études, Projets) s'aligne sur la même taille via ses classes
+     compactes (sinon Contact 14px, Projets 14px, Études 16px > 10px). */
+  .cv-short-page .cv-job-description,
+  .cv-short-page .cv-contact-value-compact,
+  .cv-short-page .cv-row-study-title-year,
+  .cv-short-page .cv-study-title-compact,
+  .cv-short-page .cv-study-year-compact {
     font-size: 0.625rem;
     line-height: 1.35;
   }
@@ -993,8 +999,14 @@ html {
 
 /* Short print-preview : CORPS de texte aux tailles d'IMPRESSION (les utilitaires
    Tailwind `print:` ne s'appliquent pas en aperçu → sinon l'aperçu montre 14px
-   alors que le PDF fait 10px). Scopé `.cv-print-preview` → vue normale intacte. */
-.cv-print-preview .cv-short-page .cv-job-description {
+   alors que le PDF fait 10px). Scopé `.cv-print-preview` → vue normale intacte.
+   La colonne secondaire (Coordonnées, Études, Projets) reprend la même taille
+   que `.cv-job-description` via ses classes compactes (sinon 14/14/16px). */
+.cv-print-preview .cv-short-page .cv-job-description,
+.cv-print-preview .cv-short-page .cv-contact-value-compact,
+.cv-print-preview .cv-short-page .cv-row-study-title-year,
+.cv-print-preview .cv-short-page .cv-study-title-compact,
+.cv-print-preview .cv-short-page .cv-study-year-compact {
   font-size: 0.625rem !important; /* 10px */
   line-height: 1.35 !important;
 }


### PR DESCRIPTION
## Problème
Sur le CV **court** (`/[lang]/short`), le corps principal (Profil, domaines, Expérience) est densifié à **10px** via `.cv-job-description`, mais trois sections de la colonne secondaire gardaient leurs tailles d'origine, plus grosses que « Professional Experience » → hiérarchie visuelle cassée :

| Section | Avant | Après |
|---|---|---|
| Contact (email/tél/lieu) | 14px | **10px** |
| Projects (`cv-study-title-compact`) | 14px | **10px** |
| Education (`cv-row-study-title-year`) | 16px | **10px** |
| *(réf.)* Professional Experience (`cv-job-description`) | 10px | 10px |

## Correctif
On ajoute les classes compactes de la colonne secondaire (`cv-contact-value-compact`, `cv-row-study-title-year`, `cv-study-title-compact`, `cv-study-year-compact`) **à la règle de densification existante** de `.cv-job-description`, dans les **deux** blocs :
- `@media print .cv-short-page …` (PDF réel)
- `.cv-print-preview .cv-short-page …` (écran + aperçu `?print=1`)

Pas de nouvelle règle custom : même sélecteur, même `0.625rem`. Scopé `.cv-short-page` → **CV complet inchangé**, **mobile non dégradé** (le corps y était déjà à 10px ; la lisibilité reste pilotée par le zoom WYSIWYG).

## Vérification (Playwright + dev server)
`getComputedStyle().fontSize` mesuré sur Contact / Études (`.cv-row-study-title-year`) / Projet (`.cv-study-title-compact`) / référence (`.cv-job-description`) :

| Rendu | contact | education | project | ref |
|---|---|---|---|---|
| `/en/short` (écran) | 10 | 10 | 10 | 10 |
| `/en/short?print=1` | 10 | 10 | 10 | 10 |
| émulation print (vp 760 + `emulateMedia('print')`) | 10 | 10 | 10 | 10 |

- CV complet `/en` : **inchangé** (pas de `.cv-short-page`, contact 16px, corps 14px).
- `npx tsc --noEmit` ✅ · `prettier --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)