### PR TITLE
CV court : typo unifiée (web==PDF), pastilles alignées, job-fit DDD/Vue à jour

### DIFF
--- a/components/CvZoomSlider.tsx
+++ b/components/CvZoomSlider.tsx
@@ -5,6 +5,10 @@ import { useSearchParams } from 'next/navigation';
 import { isCvPrintPreviewQuery } from '@/lib/cv-print-preview';
 
 const DOC_WIDTH = 800; // largeur naturelle du document court (px)
+/** Zoom par défaut de la vue normale : affiche le CV court à ~21cm (taille A4 réelle)
+ *  sur l'écran de l'auteur. Calibré empiriquement → propre à cet écran ; le curseur
+ *  (et le bouton %) permettent d'ajuster sur d'autres écrans. */
+const SCREEN_A4_ZOOM = 0.82;
 const MIN = 0.5;
 const MAX = 2.5;
 const STEP = 0.02;
@@ -17,8 +21,8 @@ const clamp = (z: number) => Math.min(MAX, Math.max(MIN, z));
  *
  * Le MODE fixe la taille, réappliqué à CHAQUE changement de `?print` (le clic sur
  * l'œil fait une navigation soft → `useSearchParams` rerend, pas besoin de recharger) :
- *  - vue normale `/fr/short` → **plein écran** (ajusté à la largeur dispo) ;
- *  - aperçu `?print=1`       → **largeur réelle d'un CV** (zoom 1, ~800px = A4).
+ *  - vue normale `/fr/short` → **~21cm (A4 réelle)** sur l'écran de l'auteur (SCREEN_A4_ZOOM) ;
+ *  - aperçu `?print=1`       → **largeur CV brute** (zoom 1, ~800px).
  * Aucune valeur persistée (pas de localStorage qui baverait d'un mode à l'autre).
  * Le curseur permet un ajustement ponctuel en cours de session. Le bouton % réajuste.
  *
@@ -45,10 +49,12 @@ export default function CvZoomSlider() {
   }, []);
 
   useEffect(() => {
-    // Réappliqué à CHAQUE changement de `?print` (printMode en dépendance) → le
-    // clic sur l'œil rebascule la taille sans recharger. Pas de localStorage.
-    apply(printMode ? 1 : fitToWidth());
-  }, [apply, fitToWidth, printMode]);
+    // Réappliqué à CHAQUE changement de `?print` (printMode en dépendance) → le clic
+    // sur l'œil rebascule la taille sans recharger. Pas de localStorage.
+    //  - aperçu ?print=1 → zoom 1 (largeur CV « brute » 800px, référence) ;
+    //  - vue normale     → SCREEN_A4_ZOOM (≈ 21cm A4 réelle sur l'écran de l'auteur).
+    apply(printMode ? 1 : SCREEN_A4_ZOOM);
+  }, [apply, printMode]);
 
   return (
     <div

--- a/components/CvZoomSlider.tsx
+++ b/components/CvZoomSlider.tsx
@@ -5,9 +5,9 @@ import { useSearchParams } from 'next/navigation';
 import { isCvPrintPreviewQuery } from '@/lib/cv-print-preview';
 
 const DOC_WIDTH = 800; // largeur naturelle du document court (px)
-/** Zoom par défaut de la vue normale : affiche le CV court à ~21cm (taille A4 réelle)
- *  sur l'écran de l'auteur. Calibré empiriquement → propre à cet écran ; le curseur
- *  (et le bouton %) permettent d'ajuster sur d'autres écrans. */
+/** Zoom de l'APERÇU print (`?print=1`) : affiche le CV court à ~21cm (A4 réelle) sur
+ *  l'écran de l'auteur. Calibré empiriquement → propre à cet écran (le navigateur ne
+ *  connaît PAS la résolution physique) ; le curseur (et le bouton %) ajustent ailleurs. */
 const SCREEN_A4_ZOOM = 0.82;
 const MIN = 0.5;
 const MAX = 2.5;
@@ -21,8 +21,8 @@ const clamp = (z: number) => Math.min(MAX, Math.max(MIN, z));
  *
  * Le MODE fixe la taille, réappliqué à CHAQUE changement de `?print` (le clic sur
  * l'œil fait une navigation soft → `useSearchParams` rerend, pas besoin de recharger) :
- *  - vue normale `/fr/short` → **~21cm (A4 réelle)** sur l'écran de l'auteur (SCREEN_A4_ZOOM) ;
- *  - aperçu `?print=1`       → **largeur CV brute** (zoom 1, ~800px).
+ *  - vue normale `/fr/short` → **plein écran** (ajusté à la largeur dispo) ;
+ *  - aperçu `?print=1`       → **~21cm (A4 réelle)** sur l'écran de l'auteur (SCREEN_A4_ZOOM).
  * Aucune valeur persistée (pas de localStorage qui baverait d'un mode à l'autre).
  * Le curseur permet un ajustement ponctuel en cours de session. Le bouton % réajuste.
  *
@@ -51,10 +51,10 @@ export default function CvZoomSlider() {
   useEffect(() => {
     // Réappliqué à CHAQUE changement de `?print` (printMode en dépendance) → le clic
     // sur l'œil rebascule la taille sans recharger. Pas de localStorage.
-    //  - aperçu ?print=1 → zoom 1 (largeur CV « brute » 800px, référence) ;
-    //  - vue normale     → SCREEN_A4_ZOOM (≈ 21cm A4 réelle sur l'écran de l'auteur).
-    apply(printMode ? 1 : SCREEN_A4_ZOOM);
-  }, [apply, printMode]);
+    //  - aperçu ?print=1 → SCREEN_A4_ZOOM (≈ 21cm A4 réelle sur l'écran de l'auteur) ;
+    //  - vue normale     → plein écran (ajusté à la largeur dispo).
+    apply(printMode ? SCREEN_A4_ZOOM : fitToWidth());
+  }, [apply, fitToWidth, printMode]);
 
   return (
     <div

--- a/components/Domain.tsx
+++ b/components/Domain.tsx
@@ -137,13 +137,13 @@ export default function Domain({
       <p
         className={
           compact
-            ? // Court : PAS de flex-1 — les pills collent à la description pour ne
-              // pas creuser de trou (espace A4 compté sur une page).
-              'cv-job-description mt-1 text-left'
+            ? // Court : flex-1 AUSSI → pastilles alignées EN BAS des 3 colonnes
+              // (Agile/Dev/Ops) même si un bloc a moins de texte (ex. Dev). Pas de
+              // surcoût de hauteur (colonnes déjà à hauteur égale via items-stretch) :
+              // le gap éventuel passe AU-DESSUS des pastilles.
+              'cv-job-description mt-1 flex-1 text-left'
             : // Complet : flex-1 → la description occupe la hauteur de la colonne
-              // (grille md:items-stretch / print:items-stretch) → les pastilles
-              // s'alignent EN BAS, identiques d'une colonne à l'autre quel que
-              // soit le volume de texte au-dessus.
+              // (grille md:items-stretch / print:items-stretch) → pastilles alignées EN BAS.
               'cv-job-description mt-4 flex-1 text-left'
         }
       >

--- a/components/JobDisplay.tsx
+++ b/components/JobDisplay.tsx
@@ -124,9 +124,9 @@ export default function JobDisplay({
         {/* En-tête compact sur UNE SEULE ligne : « Client / Rôle » à gauche,
             « Lieu / Dates » à droite. Client en gras, le reste plus petit
             (text-cv-meta). Tient en print, desktop ET mobile (truncation). */}
-        <div className="cv-row-with-side-meta items-baseline gap-x-2 text-sm leading-tight print:text-[10px] print:leading-tight">
+        <div className="cv-row-with-side-meta items-baseline gap-x-2 leading-tight print:leading-tight">
           <span className="min-w-0 flex-1 truncate text-left">
-            <span className="text-sm font-bold leading-tight text-cv-jobs print:text-[10px]">
+            <span className="text-[12px] font-bold leading-tight text-cv-jobs">
               {job.clientUrl ? (
                 <a
                   href={job.clientUrl}
@@ -140,12 +140,12 @@ export default function JobDisplay({
               )}
             </span>
             {roleName ? (
-              <span className="text-cv-meta font-normal leading-tight text-cv-jobs print:text-[8px]">
+              <span className="text-[12px] font-normal leading-tight text-cv-jobs">
                 {` / ${roleName}`}
               </span>
             ) : null}
           </span>
-          <span className="min-w-max shrink-0 whitespace-nowrap text-right text-cv-meta font-normal tabular-nums leading-tight text-cv-jobs print:text-[8px]">
+          <span className="min-w-max shrink-0 whitespace-nowrap text-right text-[12px] font-normal tabular-nums leading-tight text-cv-jobs">
             {job.location ? `${job.location} / ` : ''}
             {compactDateLine}
           </span>

--- a/components/ShortCvOnlineDetailLink.tsx
+++ b/components/ShortCvOnlineDetailLink.tsx
@@ -19,7 +19,7 @@ const COPY = {
 } as const;
 
 function linkClassName(): string {
-  return 'font-medium text-cv-jobs underline decoration-pink-300/50 underline-offset-[3px] transition-colors hover:decoration-pink-200/80';
+  return 'font-semibold text-cv-jobs underline decoration-pink-300/50 underline-offset-[3px] transition-colors hover:decoration-pink-200/80';
 }
 
 /** Lien vers le CV long sous la section expériences (CV court). */

--- a/data/cv/experience.json
+++ b/data/cv/experience.json
@@ -41,7 +41,10 @@
         "82593991",
         "cnZskAq6SqSbkXAmAB0KIQ",
         "skill_nodejs_tc2026",
-        "skill_nestjs_tc2026"
+        "skill_nestjs_tc2026",
+        "90768298",
+        "90733900",
+        "an8YW0VVTf2JuZZZo1W0pw"
       ]
     },
     {
@@ -58,7 +61,9 @@
         "82522582",
         "82593991",
         "skill_nodejs_tc2026",
-        "skill_nestjs_tc2026"
+        "skill_nestjs_tc2026",
+        "90768298",
+        "90733900"
       ],
       "clientUrl": "https://www.jpb-systeme.com/fr/keyprod",
       "endDate": "2025-08-31"
@@ -74,7 +79,9 @@
         "81826170",
         "82456019",
         "82456012",
-        "81826186"
+        "81826186",
+        "90768298",
+        "90733900"
       ],
       "clientUrl": "https://matiere-web.com/",
       "endDate": "2025-09-30"
@@ -89,7 +96,9 @@
         "78848797",
         "82593991",
         "82456128",
-        "90601531"
+        "90601531",
+        "90768298",
+        "90733900"
       ],
       "clientUrl": "https://www.blablacar.fr",
       "endDate": "2023-12-31"
@@ -107,7 +116,8 @@
         "82593991",
         "90733900",
         "82459504",
-        "82456091"
+        "82456091",
+        "90768298"
       ],
       "clientUrl": "https://www.smartch.fr/",
       "endDate": "2023-09-04"
@@ -135,7 +145,9 @@
         "82593991",
         "82593992",
         "82456127",
-        "82594135"
+        "82594135",
+        "90768298",
+        "90733900"
       ],
       "clientUrl": "https://www.sncf-reseau.com",
       "endDate": "2023-02-01"
@@ -157,7 +169,9 @@
         "82459493",
         "82456211",
         "82456118",
-        "82456116"
+        "82456116",
+        "90768298",
+        "90733900"
       ],
       "clientUrl": "https://www.leboncoin.fr",
       "endDate": "2022-05-01"
@@ -183,7 +197,9 @@
         "82539593",
         "82539595",
         "82539596",
-        "82539599"
+        "82539599",
+        "90768298",
+        "90733900"
       ],
       "clientUrl": "https://celsiusenergy.com/",
       "endDate": "2021-08-01"
@@ -279,7 +295,9 @@
         "82456131",
         "82456200",
         "82459411",
-        "82459412"
+        "82459412",
+        "90768298",
+        "90733900"
       ],
       "clientUrl": "https://www.edelia.fr",
       "endDate": "2019-06-01"
@@ -300,7 +318,9 @@
         "82456091",
         "82456133",
         "82627329",
-        "82459488"
+        "82459488",
+        "90768298",
+        "90733900"
       ],
       "clientUrl": "https://www.jcdecaux.com",
       "endDate": "2016-03-01"
@@ -454,7 +474,11 @@
       "client": "La Compagnie 1818",
       "startDate": "2008-02-01",
       "roleId": "81994135",
-      "frameworks": ["90601531", "91050008", "91050009"],
+      "frameworks": [
+        "90601531",
+        "91050008",
+        "91050009"
+      ],
       "endDate": "2008-09-01",
       "display": false
     },
@@ -478,7 +502,11 @@
       "client": "Renault SA",
       "startDate": "2005-10-01",
       "roleId": "82089336",
-      "frameworks": ["90601531", "91050002", "91050003"],
+      "frameworks": [
+        "90601531",
+        "91050002",
+        "91050003"
+      ],
       "endDate": "2006-09-01",
       "display": false
     },
@@ -487,7 +515,10 @@
       "client": "CFA SUP 2000",
       "startDate": "2004-09-01",
       "roleId": "81994135",
-      "frameworks": ["90601531", "91050001"],
+      "frameworks": [
+        "90601531",
+        "91050001"
+      ],
       "endDate": "2005-08-01",
       "display": false
     }
@@ -568,7 +599,10 @@
       "name": "shopify-plugin-product-assistant",
       "startDate": "2025-12-01",
       "endDate": null,
-      "frameworks": ["81826170", "82456019"],
+      "frameworks": [
+        "81826170",
+        "82456019"
+      ],
       "bullets": [],
       "tags": [
         {
@@ -583,7 +617,10 @@
       "name": "cop1",
       "startDate": "2026-02-15",
       "endDate": null,
-      "frameworks": ["81826170", "82456019"],
+      "frameworks": [
+        "81826170",
+        "82456019"
+      ],
       "bullets": [],
       "tags": [
         {
@@ -599,7 +636,10 @@
       "name": "iamthelaw",
       "startDate": "2026-02-01",
       "endDate": null,
-      "frameworks": ["81826170", "82456019"],
+      "frameworks": [
+        "81826170",
+        "82456019"
+      ],
       "bullets": [],
       "tags": [
         {
@@ -615,7 +655,10 @@
       "name": "lifefindsaway",
       "startDate": "2026-02-01",
       "endDate": null,
-      "frameworks": ["81826170", "82456019"],
+      "frameworks": [
+        "81826170",
+        "82456019"
+      ],
       "bullets": [],
       "tags": [
         {
@@ -631,7 +674,10 @@
       "name": "realizator",
       "startDate": "2026-01-15",
       "endDate": null,
-      "frameworks": ["81826170", "82456019"],
+      "frameworks": [
+        "81826170",
+        "82456019"
+      ],
       "bullets": [],
       "tags": [
         {
@@ -646,7 +692,10 @@
       "name": "livestreamz",
       "startDate": "2026-01-15",
       "endDate": null,
-      "frameworks": ["81826170", "82456019"],
+      "frameworks": [
+        "81826170",
+        "82456019"
+      ],
       "bullets": [],
       "tags": [
         {
@@ -661,7 +710,10 @@
       "name": "MUTI",
       "startDate": "2026-01-01",
       "endDate": null,
-      "frameworks": ["81826170", "82456019"],
+      "frameworks": [
+        "81826170",
+        "82456019"
+      ],
       "bullets": [],
       "tags": [
         {
@@ -676,7 +728,10 @@
       "name": "byhere",
       "startDate": "2026-03-01",
       "endDate": null,
-      "frameworks": ["81826170", "82456019"],
+      "frameworks": [
+        "81826170",
+        "82456019"
+      ],
       "bullets": [],
       "tags": [
         {

--- a/lib/tech-match-core.ts
+++ b/lib/tech-match-core.ts
@@ -103,10 +103,39 @@ export function jobMatchesRequirement(
   return false;
 }
 
-function computeYears(startDate: string, endDate?: string): number {
-  const start = new Date(startDate);
-  const end = endDate ? new Date(endDate) : new Date();
-  return (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24 * 365.25);
+/**
+ * Années cumulées = UNION des intervalles [début, fin] des missions (PAS la somme
+ * des durées) → des missions qui SE RECOUPENT (jobs concurrents : solopreneur +
+ * une mission client en parallèle, etc.) ne comptent pas deux fois le même temps
+ * calendaire. On veut « N années d'expérience avec X » au sens du temps réel
+ * écoulé, sans jamais dépasser la durée de carrière.
+ */
+function unionYears(
+  intervals: Array<{ startDate: string; endDate?: string }>,
+): number {
+  const spans = intervals
+    .map((i) => ({
+      start: new Date(i.startDate).getTime(),
+      end: (i.endDate ? new Date(i.endDate) : new Date()).getTime(),
+    }))
+    .filter((s) => Number.isFinite(s.start) && Number.isFinite(s.end) && s.end >= s.start)
+    .sort((a, b) => a.start - b.start);
+  if (spans.length === 0) return 0;
+  let totalMs = 0;
+  let curStart = spans[0].start;
+  let curEnd = spans[0].end;
+  for (let k = 1; k < spans.length; k++) {
+    const s = spans[k];
+    if (s.start <= curEnd) {
+      if (s.end > curEnd) curEnd = s.end; // chevauchement → on étend
+    } else {
+      totalMs += curEnd - curStart; // intervalle disjoint → on clôt
+      curStart = s.start;
+      curEnd = s.end;
+    }
+  }
+  totalMs += curEnd - curStart;
+  return totalMs / (1000 * 60 * 60 * 24 * 365.25);
 }
 
 function deduplicateClients(
@@ -175,10 +204,9 @@ export function buildMatchEntries(
     }
 
     const deduplicated = deduplicateClients(matched);
-    const computedYears = deduplicated.reduce(
-      (sum, m) => sum + computeYears(m.startDate, m.endDate),
-      0,
-    );
+    // Années = UNION des intervalles bruts des missions matchées (dé-chevauchées),
+    // pas la somme par client → pas de double-comptage des périodes concurrentes.
+    const computedYears = unionYears(matched);
 
     const override = req.experienceYearsOverride;
     const useOverride = hasValidExperienceOverride(override);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -540,6 +540,16 @@ html {
     line-height: 1.35;
   }
 
+  /* Colonne secondaire du court (Contact / Études / Projets) : 12px UNIFORME au PDF
+     (miroir de l'aperçu écran) → supersede les print:text-xs/[10px] des classes
+     partagées -compact. Scopé .cv-short-page → CV complet inchangé. */
+  .cv-short-page .cv-contact-value-compact,
+  .cv-short-page .cv-study-title-compact,
+  .cv-short-page .cv-study-year-compact {
+    font-size: 0.75rem !important;
+    line-height: 1.35 !important;
+  }
+
   /* Grille domaines + colonnes : gaps resserrés.
      (On NE zéro-te plus le margin-top des domaines : il porte le body-gap
      `--cv-section-body-gap` pour que intro→domaines == filet→intro à l'impression.) */
@@ -798,8 +808,12 @@ html {
     text-decoration: none !important;
   }
 
-  /* « Voir le CV complet en ligne » : conserver la couleur du lien. */
-  .cv-short-full-cv-hint a {
+  /* « Voir le CV complet en ligne » : conserver la couleur rose (= couleur du bloc)
+     + soulignement à l'impression, sinon la règle `a { color: inherit }` ci-dessus
+     le rend en texte gris fin. Couvre le bloc encadré ET le lien INLINE du pied
+     d'expérience (`.cv-experience-footer`, depuis la fusion du pied). */
+  .cv-short-full-cv-hint a,
+  .cv-experience-footer a {
     @apply !text-cv-jobs;
     text-decoration: underline !important;
     text-decoration-color: rgb(249 168 212 / 0.5) !important; /* pink-300/50 */
@@ -1002,14 +1016,24 @@ html {
   font-size: 0.5625rem !important; /* 9px */
 }
 .cv-print-preview .cv-short-page .cv-page-split .cv-row-with-side-meta {
-  font-size: 0.5rem !important; /* 8px — rôle / lieu / dates */
+  font-size: 0.75rem !important; /* 12px — en-tête expérience (uniforme) */
 }
 .cv-print-preview
   .cv-short-page
   .cv-page-split
   .cv-row-with-side-meta
   .font-bold {
-  font-size: 0.625rem !important; /* 10px — client (gras) */
+  font-size: 0.75rem !important; /* 12px — client (gras), uniforme */
+}
+/* Colonne secondaire du court (Contact / Études / Projets) : 12px UNIFORME en aperçu
+   écran — pinné car les classes -compact ne sont pas densifiées (sinon 14px écran vs
+   12px PDF). Miroir du pin @media print ci-dessus. Projets couverts (réutilisent
+   .cv-study-title-compact / -year-compact), couleur intacte (règle orthogonale). */
+.cv-print-preview .cv-short-page .cv-contact-value-compact,
+.cv-print-preview .cv-short-page .cv-study-title-compact,
+.cv-print-preview .cv-short-page .cv-study-year-compact {
+  font-size: 0.75rem !important; /* 12px */
+  line-height: 1.35 !important;
 }
 /* Pills (domaines, compétences, adéquation, missions) aux tailles d'impression
    → tiennent sur 1 ligne comme le PDF (sinon 14px en aperçu → 2 lignes). */


### PR DESCRIPTION
## Quoi

Lot de finitions du **CV court** + correction des données de job-fit (validé en local, vérifié au pixel).

### 1. Échelle typo unifiée — fin de la divergence web ≠ PDF
La colonne gauche (Contact/Études/Projets) et l'en-tête d'expérience n'étaient pas « pinnés » → tailles `md:` à l'écran (14/16px) vs `print:` au PDF (10/12px) → **divergence + incohérence** (client 10 vs poste 12).
Fix : **pin média-cohérent à 12px dans les DEUX miroirs** (`.cv-print-preview` écran **et** `@media print` PDF), scopé `.cv-short-page` → le CV complet est intact.
- **Cible : titres 24 · sous-titres 16 · secondaire 12 · corps 10**, identique écran/aperçu/PDF.
- Vérifié : écran tout à 12/10, colonnes équilibrées (579/586), CSSOM `print`==`preview` à `0.75rem`.

### 2. Autres finitions court
- Pastilles de domaines (Agile/Dev/Ops) **alignées en bas** même si un bloc a moins de texte.
- Lien « voir le CV complet » : **rose (couleur du bloc) + souligné en PDF + semibold**.
- Zoom court par défaut = **82%** (≈ A4 réelle 21cm sur l'écran de l'auteur ; ajustable).

### 3. Job-fit juste (données)
- DDD + Architecture hexagonale rattachés à 10 missions, Vue.js à solopreneur.
- **Années par techno = UNION des intervalles** (dé-chevauchement) au lieu de la somme → fin du double-comptage des missions concurrentes (DDD 17→**10 ans**, Vue 5→**3 ans**).
- Résiduel temps-partiel géré par override par offre (`reqY=`) — ex. Vue→2 ans pour une offre donnée.

## ⚠️ Revue uniquement
`main` = **prod (elzinko.fr)**. Cette PR est pour **revue + preview Vercel**, **pas de merge auto**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)