### PR TITLE
fix(cv): lien « CV complet » absolu (DNS dynamique + params) dans le PDF exporté

### DIFF
--- a/components/ShortCvOnlineDetailLink.tsx
+++ b/components/ShortCvOnlineDetailLink.tsx
@@ -2,8 +2,9 @@
 
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { fullHrefFromShortPath } from '@/lib/cv-mode-nav';
+import { CV_VIEWPORT_PARAM } from '@/lib/cv-viewport-mobile';
 
 const COPY = {
   fr: {
@@ -33,10 +34,30 @@ export default function ShortCvOnlineDetailLink({
 }) {
   const sp = useSearchParams();
   const queryKey = sp.toString();
-  const href = useMemo(
-    () => fullHrefFromShortPath(lang, new URLSearchParams(queryKey)),
-    [lang, queryKey],
-  );
+
+  // Origine capturée après le montage : produit un lien ABSOLU (même DNS, repris
+  // dynamiquement de la page courante — prod, preview Vercel, etc.) dans le PDF
+  // exporté, sans casser l'hydratation. Le rendu serveur reste relatif et laisse
+  // Next préfixer le `basePath`.
+  const [origin, setOrigin] = useState('');
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
+
+  const href = useMemo(() => {
+    // Reprend les paramètres d'offre de l'URL courante, sans les paramètres
+    // d'état d'UI (`print`, `cvViewport`) qui n'ont pas de sens pour le lecteur.
+    const params = new URLSearchParams(queryKey);
+    params.delete('print');
+    params.delete(CV_VIEWPORT_PARAM);
+    const relative = fullHrefFromShortPath(lang, params);
+    if (!origin) return relative;
+    const basePath = (process.env.NEXT_PUBLIC_BASE_PATH || '').replace(
+      /\/$/,
+      '',
+    );
+    return `${origin}${basePath}${relative}`;
+  }, [lang, queryKey, origin]);
 
   const t = COPY[lang];
 


### PR DESCRIPTION
## Quoi

Dans le CV court, le lien de bas de page **« voir le CV complet en ligne »** est désormais une **URL absolue** au lieu d'un href relatif.

Avant : `href="/fr?company=…"` (relatif)
Après : `href="https://<domaine-courant>/fr?company=…"` (absolu, DNS dynamique)

## Pourquoi

Dans le **PDF exporté** (`window.print()`), un lien relatif n'a pas de domaine fiable et ne pouvait pas reprendre dynamiquement le bon DNS selon le déploiement (prod vs preview Vercel, ex. `my-resume-git-…vercel.app`). Le lecteur du PDF doit pouvoir cliquer un lien qui pointe vers le même site, avec la même offre.

## Comment

- L'origine est lue via `window.location.origin`, **capturée dans un `useEffect`** après montage → le rendu serveur reste relatif (laisse Next préfixer le `basePath`), donc **pas de mismatch d'hydratation**.
- L'URL finale = `origin` + `basePath` + `/[lang]` + **paramètres d'offre courants** (`company`, `title`, `requirement`, `contract`, …).
- Les paramètres d'**état d'UI** (`print`, `cvViewport`) sont **retirés** : le destinataire atterrit sur le vrai CV complet, pas sur un aperçu impression ou la vue mobile.

## Vérification

- `tsc --noEmit` : OK.
- Test navigateur réel (dev server) sur `/fr/short?company=iad&title=Engineering+Manager&contract=cdi&requirement=…&print=1&cvViewport=mobile` → le lien rendu :
  `http://localhost:3939/fr?company=iad&title=Engineering+Manager&contract=cdi&requirement=Architecture+%26+Craft%3Addd%2Cclean+architecture`
  (origine incluse, params d'offre conservés, `print`/`cvViewport` retirés).

## Portée

Un seul fichier : `components/ShortCvOnlineDetailLink.tsx`. Aucun test e2e n'asserte sur ce lien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)