### PR TITLE
fix(cv): abrège « Architecture hexagonale » → « Hexagonal » (catalogue tech)

### DIFF
--- a/data/cv/tech-catalog.json
+++ b/data/cv/tech-catalog.json
@@ -48,9 +48,9 @@
     },
     {
       "id": "skill_hexa_tc2026",
-      "name": "Architecture hexagonale",
+      "name": "Hexagonal",
       "link": "https://alistair.cockburn.us/hexagonal-architecture/",
-      "nameEn": "Hexagonal architecture"
+      "nameEn": "Hexagonal"
     },
     {
       "id": "skill_nodejs_tc2026",
@@ -203,7 +203,7 @@
     },
     {
       "id": "90733900",
-      "name": "Hexagonal architecture",
+      "name": "Hexagonal",
       "link": "https://en.wikipedia.org/wiki/Hexagonal_architecture_(software)"
     },
     {


### PR DESCRIPTION
Le libellé « Architecture hexagonale » prenait trop de place dans le CV → raccourci en **« Hexagonal »** (FR + EN, 2 entrées du `tech-catalog.json`).

Propage la seule modif utile de #103 (le reste de #103 est superseded par #106). Aligné sur job-app #131. Diff byte-identique (`9377b92..851341c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)