### PR TITLE
fix(cv): impression CV complet — écart uniforme avant « Expérience »

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -806,10 +806,12 @@ html {
     page-break-inside: auto !important;
   }
 
-  /* Espacement avant la section Experience pour eviter un titre orphelin en bas de page. */
-  .cv-print-jobs-group {
-    padding-top: 1rem;
-  }
+  /* Rythme inter-sections UNIFORME avant « Expérience » : pas de padding ici.
+     Un `padding-top` créait +1rem d'écart avant le titre Expérience vs les autres
+     sections (seulement en impression/aperçu → le web, lui, était bon). L'écart est
+     désormais porté par le seul flex-gap de `.cv-full-cv-print-root`, comme partout.
+     L'anti-titre-orphelin est déjà assuré par `break-after: avoid` sur les `h2`
+     (cf. plus haut) → un titre n'est jamais seul en bas de page. */
 
   /**
    * Le bouton écran « Masquer les détails » ne doit JAMAIS affecter le PDF :
@@ -1198,8 +1200,4 @@ html {
 .cv-print-preview .cv-full-cv-print-root #jobs {
   break-before: auto !important;
   page-break-before: auto !important;
-}
-
-.cv-print-preview .cv-print-jobs-group {
-  padding-top: 1rem;
 }


### PR DESCRIPTION
## Problème
En **impression du CV complet** (et aperçu `?print=1`), le titre **« Expérience professionnelle »** avait plus d'espace au-dessus que les autres sections. En **web** c'était bon.

## Cause
`.cv-print-jobs-group { padding-top: 1rem }` — dans `@media print` **et** `.cv-print-preview` (contextes actifs en impression/aperçu mais pas sur le web → écart visible seulement à l'impression). Censé « éviter un titre orphelin », rôle déjà tenu par `break-after: avoid` sur les `h2`. Redondant + nuisible.

## Fix
Retrait des deux `padding-top: 1rem`. L'écart avant Expérience est porté par le seul flex-gap de `.cv-full-cv-print-root`, comme partout → **impression = web**.

## Vérif Playwright (avant → après, FR, print + aperçu)
| | Avant | Après |
|---|---|---|
| Gap titre « Expérience » | 36px | **21px** (uniforme) |
| CV complet — pages | 5 | 5 |
| CV court — pages | 1 | **1** |

👉 **Une preview Vercel est déployée sur cette PR** — à valider à l'œil (c'était l'objet du retour : le fix avait d'abord été poussé sur job-app, sans preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)