### PR TITLE
docs(cv): garde-fous anti-dérive web/impression (CLAUDE.md + ADR + checklist)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md — règles projet (auto-chargées)
+
+Guide court pour toute session Claude Code sur ce repo. Objectif : **arrêter les
+dérives entre le rendu web et le rendu impression du CV**, qui reviennent après
+chaque feature. Lis la section « Rendu CV » avant TOUTE modif de style/mise en page.
+
+## Rendu CV — le modèle mental (à ne pas oublier)
+
+Il n'y a **qu'un seul DOM React** (le contenu est unique, jamais dupliqué). Le PDF
+est produit par le **moteur d'impression du navigateur** (`Cmd+P` / `window.print()`
+déclenché par `CvAutoprint`) sur ce même DOM. Il n'y a **pas** de moteur PDF séparé.
+
+Ce qui change l'apparence = une **couche CSS par régime**, posée sur le DOM commun :
+
+| Régime     | Déclencheur                     | Où                                                                       |
+| ---------- | ------------------------------- | ------------------------------------------------------------------------ |
+| **Web**    | vue normale                     | classes de base + `md:`                                                  |
+| **Aperçu** | `?print=1` (et pendant `Cmd+P`) | classe `.cv-print-preview` sur `<html>` (cf. `FullCvPrintPreviewEffect`) |
+| **PDF**    | impression réelle               | `@media print`                                                           |
+
+Et il y a **2 layouts distincts** : CV complet (`OfferTailoredShell`) et CV court
+(`CompactCvLayout`, route `/[lang]/short`). Donc **4 rendus** à garder cohérents :
+`complet-web`, `complet-print`, `court-web`, `court-print` (+ le mobile).
+
+**La dérive vient de là** : une règle « print » doit souvent être écrite DEUX fois
+(`@media print` ET `.cv-print-preview`). Corriger l'une en oubliant l'autre = l'aperçu
+ment sur le PDF (ou l'inverse). Une modif « web-only » n'a aucun effet sur le print.
+
+## Invariants (respecter, sinon on recrée la dérive)
+
+1. **WYSIWYG** : `web == aperçu ?print == PDF`. Toute modif visuelle doit être
+   répercutée dans **les 3 régimes** (et les 2 layouts si concerné). Ne jamais livrer
+   une modif qui n'a été vue que dans un seul régime.
+2. **Pas de règle print orpheline** : toute règle d'impression doit valoir pour
+   `@media print` **ET** `.cv-print-preview`. Préférer un **sélecteur combiné**
+   (`@media print, .cv-print-preview { … }` ou une classe/variable partagée) plutôt
+   que deux copies qui divergeront.
+3. **`.cv-print-preview` est PERMANENT sur `/short`** (cf. `short/layout.tsx`). Donc
+   toute règle `.cv-print-preview .cv-short-page …` qui impose des **tailles A4**
+   (≈ 9–12px) doit être bornée `@media (min-width: 768px)` : sous `md`, le CV court
+   retombe sur la typo responsive lisible (`text-base`). Le PDF garde ses tailles via
+   les copies `@media print`. (Cf. le fix « CV court lisible sur mobile ».)
+4. **CV court sous `md` = vue mobile 1:1**, jamais un A4 réduit (pas de `zoom` < 1 :
+   `CvZoomSlider` force `zoom = 1` sous `md`).
+5. **Entrées de liste** (Études, Projets, Loisirs…) : date/année **colorée et collée
+   à droite** dans tous les régimes ; le détail (école, description) inline ou sur 2
+   lignes selon `?entriesLayout` (défaut : inline).
+6. **Tokens d'espacement** : passer par `--cv-section-gap` / `--cv-section-body-gap`,
+   pas de marges par section codées en dur (évite le margin-collapse et la dérive de
+   rythme entre régimes).
+
+## Vérification obligatoire avant toute PR touchant le rendu CV
+
+Lancer le dev server et **vérifier les 4 rendus + le mobile** (Playwright), pas un
+seul. Checklist détaillée : [`docs/cv-rendering-review-checklist.md`](docs/cv-rendering-review-checklist.md).
+Décision d'archi et rationale : [`docs/adr/0001-cv-rendering-regimes.md`](docs/adr/0001-cv-rendering-regimes.md).
+
+Rappel : `renders/` contient des captures de référence des 4 modes — utile comme
+diff visuel avant/après.
+
+## Divers
+
+- Paramètres d'URL (offre, `?print`, `?photo`, `?age`, `?ats`, `?entriesLayout`, …)
+  pilotent le rendu : les préserver et les documenter à l'ajout.
+- `npm test` = `prettier:check` + `lint`. Formater avant de committer.
+- Commits : Conventional Commits en français (`fix(cv): …`, `feat(cv): …`).

--- a/docs/adr/0001-cv-rendering-regimes.md
+++ b/docs/adr/0001-cv-rendering-regimes.md
@@ -1,0 +1,77 @@
+# ADR 0001 — Rendu du CV : un seul DOM, régimes pilotés par CSS
+
+- **Statut** : accepté
+- **Date** : 2026-07-02
+- **Contexte associé** : dérives récurrentes web ↔ impression ; PR #108 (écart
+  « Expérience »), fix « CV court lisible sur mobile ».
+
+## Contexte
+
+Le CV (complet et court) est rendu par des composants React. Le PDF est produit par
+le **moteur d'impression du navigateur** (`window.print()` via `CvAutoprint`) sur le
+**même DOM** que la vue web — il n'existe pas de pipeline PDF séparé.
+
+Les différences d'apparence entre web, aperçu et PDF sont donc obtenues par une
+**couche CSS spécifique à chaque régime**, sur un DOM commun :
+
+- **Web** : classes de base + variantes `md:`.
+- **Aperçu écran** (`?print=1`, et pendant `Cmd+P`) : classe `.cv-print-preview` sur
+  `<html>` (`FullCvPrintPreviewEffect`), qui **duplique** les règles d'impression pour
+  que l'aperçu colle au PDF sans écouter `@media print`.
+- **PDF réel** : `@media print`.
+
+Deux layouts coexistent : CV complet (`OfferTailoredShell`, flux linéaire
+`.cv-full-cv-print-root`) et CV court (`CompactCvLayout`, route `/[lang]/short`, qui
+force `.cv-print-preview` **en permanence** pour que sa vue normale soit un aperçu A4
+fidèle).
+
+## Problème observé
+
+La duplication `@media print` ⟺ `.cv-print-preview` (et les 2 layouts) crée **4+
+rendus** à maintenir cohérents à la main. Symptômes récurrents :
+
+- une correction appliquée à `@media print` mais pas à `.cv-print-preview` (ou
+  l'inverse) → l'aperçu ment sur le PDF (ex. PR #108, padding avant « Expérience ») ;
+- une amélioration « web » sans équivalent print → régimes divergents (ex. dates à
+  droite en grille sur web, mais inline avec tirets en print) ;
+- le CV court, `.cv-print-preview` permanent + `zoom` d'ajustement A4, devient
+  illisible sur mobile (typo 10px réduite à 50 %).
+
+On **redécouvre** ces écarts après coup, en prod.
+
+## Décision
+
+On **garde** l'architecture « un seul DOM, régimes CSS » (le contenu unique est un
+atout : pas de duplication de markup, bonne accessibilité, ATS OK). Mais on
+**encadre** la maintenance par des invariants explicites et vérifiables :
+
+1. **WYSIWYG** : `web == aperçu == PDF`. Une modif visuelle se valide dans les 3
+   régimes et les 2 layouts, jamais un seul.
+2. **Pas de règle print orpheline** : privilégier un **sélecteur combiné**
+   `@media print, .cv-print-preview { … }` (ou une variable/classe partagée) plutôt
+   que deux copies. Réduire la duplication au fil de l'eau quand on touche une zone.
+3. **Garde-fou mobile du court** : les règles `.cv-print-preview .cv-short-page` qui
+   imposent des tailles A4 sont bornées `@media (min-width: 768px)` ; sous `md`, le
+   court est une vue mobile 1:1 (`zoom = 1`, typo de base).
+4. **Entrées de liste** : année colorée à droite dans tous les régimes ; layout
+   inline/2-lignes piloté par `?entriesLayout` (défaut inline).
+
+Ces invariants vivent dans [`CLAUDE.md`](../../CLAUDE.md) (auto-chargé par Claude
+Code) et sont contrôlés par [`docs/cv-rendering-review-checklist.md`](../cv-rendering-review-checklist.md).
+
+## Alternatives écartées
+
+- **Composant d'impression séparé** (fork du markup pour le PDF) : duplique le
+  contenu, casse l'unicité (accessibilité/ATS/SEO), double la surface de bug. Rejeté.
+- **PDF server-side dédié** (Playwright/puppeteer headless en prod) : infra en plus,
+  divergence garantie avec la vue web. Rejeté (le `renders/` via Playwright reste un
+  outil de **test**, pas le chemin de production).
+
+## Conséquences
+
+- **+** Contenu unique conservé ; règles claires ; dérives détectables en revue.
+- **−** La cohérence reste portée par la discipline (invariants + checklist + revue),
+  pas par le compilateur. D'où l'intérêt de `CLAUDE.md` (les agents LLM les
+  appliquent automatiquement) et, à terme, d'un diff visuel automatisé des 4 rendus.
+- **Suivi** : migrer progressivement les paires de règles dupliquées vers des
+  sélecteurs combinés ; ajouter un check de régression visuelle (snapshots `renders/`).

--- a/docs/cv-rendering-review-checklist.md
+++ b/docs/cv-rendering-review-checklist.md
@@ -1,0 +1,51 @@
+# Checklist de revue — modif du rendu CV
+
+À dérouler pour **toute PR** qui touche le rendu du CV (styles, mise en page,
+composants de section, `globals.css`, régimes print/aperçu). But : ne plus
+**redécouvrir en prod** un écart web ↔ impression. Voir l'[ADR 0001](adr/0001-cv-rendering-regimes.md)
+et [`CLAUDE.md`](../CLAUDE.md).
+
+## 1. Les 4 rendus + mobile (obligatoire)
+
+Lancer le dev server, puis vérifier **chaque** rendu (Playwright ou navigateur) :
+
+- [ ] **Complet web** — `/[lang]` (desktop ~1280px)
+- [ ] **Complet aperçu/PDF** — `/[lang]?print=1` (doit être identique au PDF `Cmd+P`)
+- [ ] **Court web** — `/[lang]/short` (desktop)
+- [ ] **Court aperçu/PDF** — `/[lang]/short?print=1`
+- [ ] **Mobile** — complet ET court à ~390–412px (Pixel) : lisible, 1 colonne, pas de
+      débordement horizontal, **pas** de rendu A4 réduit sur le court
+
+> Astuce : comparer aux captures de référence dans `renders/` (avant/après).
+
+## 2. Cohérence des régimes (la source de dérive)
+
+- [ ] La modif est **répercutée dans les 3 régimes** (web / `.cv-print-preview` /
+      `@media print`), pas seulement celui que je regardais.
+- [ ] Toute règle d'impression ajoutée existe pour **`@media print` ET
+      `.cv-print-preview`** — idéalement via un **sélecteur combiné** plutôt que 2 copies.
+- [ ] Aucune règle `.cv-print-preview .cv-short-page` n'impose de taille A4 **sans**
+      garde-fou `@media (min-width: 768px)` (sinon le court casse sur mobile).
+- [ ] Espacements via `--cv-section-gap` / `--cv-section-body-gap` (pas de marge par
+      section codée en dur).
+
+## 3. Non-régression
+
+- [ ] CV court : tient toujours sur **1 page A4** à l'impression (pas de 2e page).
+- [ ] CV complet : pagination inchangée (nb de pages), pas de titre orphelin.
+- [ ] Paramètres d'URL toujours respectés (`?print`, `?photo`, `?age`, `?ats`,
+      `?entriesLayout`, offre…).
+- [ ] Couleurs de section / pastilles préservées en print (`print:!text-*`).
+
+## 4. Qualité
+
+- [ ] `npm test` (prettier + lint) OK ; `npx tsc --noEmit` OK.
+- [ ] Message de commit : Conventional Commit FR, décrivant l'impact **par régime**.
+
+---
+
+### Pour un reviewer (humain ou agent `ezk-reviewer`)
+
+Question systématique : « cette modif a-t-elle été **vue et validée dans les 4
+rendus** ? » Si la description de PR ne montre qu'un régime → demander les captures
+manquantes avant d'approuver.


### PR DESCRIPTION
Réponse à la question « comment est généré le rendu d'impression et comment éviter les dérives web ↔ print avec les LLM / Claude Code ». **Aucun changement de code de rendu** — que de la doc.

## Le constat (l'explication demandée)

Le PDF est produit par le **moteur d'impression du navigateur** (`window.print()` via `CvAutoprint`) sur **le même DOM** que la vue web — pas de pipeline PDF séparé. Le contenu est donc bien unique. Ce qui diverge, c'est **le CSS par régime** :

- **Web** (classes de base + `md:`)
- **Aperçu** `?print=1` (classe `.cv-print-preview`, qui **duplique** les règles d'impression)
- **PDF** (`@media print`)

× **2 layouts** (complet `OfferTailoredShell` / court `CompactCvLayout`) = **4 rendus** à garder cohérents à la main. La dérive vient de la **duplication** `@media print` ⟺ `.cv-print-preview` (corriger l'une, oublier l'autre) et des modifs « web-only » sans équivalent print.

## Ce que la PR ajoute

- **`CLAUDE.md`** (racine, **auto-chargé** par Claude Code) : modèle mental + invariants (WYSIWYG, pas de règle print orpheline, garde-fou mobile du court, dates à droite tous régimes). → ta session parallèle applique déjà ces règles.
- **`docs/adr/0001-cv-rendering-regimes.md`** : la décision d'archi, alternatives écartées (composant print séparé, PDF server-side), conséquences, suivi.
- **`docs/cv-rendering-review-checklist.md`** : checklist de revue (4 rendus + mobile, cohérence des régimes, non-régression) — utilisable par toi ou par l'agent `ezk-reviewer`.

## Comment gérer ça avec les LLM (résumé)

1. `CLAUDE.md` = les invariants suivent automatiquement chaque session.
2. Checklist = le reviewer (humain/agent) exige les 4 rendus avant d'approuver.
3. Piste suivante : migrer les paires de règles dupliquées vers des **sélecteurs combinés** `@media print, .cv-print-preview { … }`, et automatiser un **diff visuel** des 4 rendus (`renders/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)