### PR TITLE
test(cv): e2e — rythme inter-sections uniforme en impression (garde-fou #108)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,43 @@
+# E2E workflow — runs ONLY the print section-rhythm spec (regression net for my-resume#108).
+#
+# Deliberately NOT the full Playwright suite: e2e/dev-components.spec.ts carries
+# darwin pixel snapshots that would fail on ubuntu runners.
+#
+# The Playwright webServer (playwright.config.ts) runs `next start` on :3457, which
+# needs a prior production build — so we `npm run build` before `playwright test`.
+name: E2E
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  print-rhythm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright (chromium)
+        run: npx playwright install --with-deps chromium
+
+      - name: Build
+        run: npm run build
+
+      - name: Run print section-rhythm e2e
+        run: npx playwright test e2e/print-section-rhythm.spec.ts

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true

--- a/e2e/print-section-rhythm.spec.ts
+++ b/e2e/print-section-rhythm.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Rythme inter-sections uniforme à l'IMPRESSION (CV long, flux linéaire).
+ *
+ * Filet de régression du bug my-resume#108 : un `padding-top: 1rem` parasite
+ * sur `.cv-print-jobs-group` ajoutait ~1rem d'écart AVANT « Expérience », cassant
+ * le rythme vertical régulier obtenu via le `gap` flex de `.cv-full-cv-print-root`.
+ *
+ * Invariante : l'écart vertical avant chaque titre de section
+ * (`top(<h2> de la section i)` − `bottom(bloc i-1)`) doit être identique d'une
+ * section à l'autre (tolérance 4px). On ordonne les enfants par position réelle
+ * car `.cv-full-cv-print-root` réordonne ses items via `order` en flex.
+ *
+ * On ne compare que des blocs « section » consécutifs (un `<section>` ou le
+ * groupe `.cv-print-jobs-group`) : le bloc d'intro (À propos / Compétences) n'est
+ * pas une section-pair et son écart au premier titre est légitimement différent.
+ */
+
+async function sectionGaps(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const root = document.querySelector('.cv-full-cv-print-root');
+    if (!root) throw new Error('.cv-full-cv-print-root introuvable');
+
+    const isSectionBlock = (el: Element) =>
+      el.tagName.toLowerCase() === 'section' ||
+      el.classList.contains('cv-print-jobs-group');
+
+    // Ordonner les enfants par position verticale réelle (flex `order`).
+    const blocks = Array.from(root.children)
+      .map((el) => ({ el, rect: el.getBoundingClientRect() }))
+      .filter(({ rect }) => rect.height > 0)
+      .sort((a, b) => a.rect.top - b.rect.top);
+
+    const gaps: { label: string; gap: number }[] = [];
+    for (let i = 1; i < blocks.length; i++) {
+      const prev = blocks[i - 1];
+      const cur = blocks[i];
+      if (!isSectionBlock(prev.el) || !isSectionBlock(cur.el)) continue;
+      const h2 = cur.el.querySelector('h2');
+      if (!h2) continue;
+      const gap = h2.getBoundingClientRect().top - prev.rect.bottom;
+      gaps.push({ label: (h2.textContent || '').trim().slice(0, 24), gap });
+    }
+    return gaps;
+  });
+}
+
+async function assertUniformRhythm(
+  page: import('@playwright/test').Page,
+  path: string,
+) {
+  await page.goto(path);
+  await page.emulateMedia({ media: 'print' });
+
+  const gaps = await sectionGaps(page);
+  expect(
+    gaps.length,
+    'au moins 3 écarts inter-sections à mesurer',
+  ).toBeGreaterThanOrEqual(3);
+
+  const values = gaps.map((g) => g.gap);
+  const spread = Math.max(...values) - Math.min(...values);
+  expect(
+    spread,
+    `rythme inter-sections uniforme (${path}) — écarts: ${gaps
+      .map((g) => `${g.label}=${g.gap.toFixed(1)}`)
+      .join(', ')}`,
+  ).toBeLessThanOrEqual(4);
+
+  await page.emulateMedia({ media: 'screen' });
+}
+
+test.describe('Rythme inter-sections uniforme (impression)', () => {
+  test.use({ viewport: { width: 1200, height: 900 } });
+
+  test('CV long FR : écarts avant chaque titre identiques', async ({
+    page,
+  }) => {
+    await assertUniformRhythm(page, '/fr');
+  });
+
+  test('CV long EN : écarts avant chaque titre identiques', async ({
+    page,
+  }) => {
+    await assertUniformRhythm(page, '/en');
+  });
+});


### PR DESCRIPTION
Fiche backlog **0018** (P2). Filet e2e déterministe qui encode l'invariante qui aurait attrapé le bug **#108** (un `padding-top:1rem` parasite → +1rem d'écart avant « Expérience » à l'impression).

## Le test (`e2e/print-section-rhythm.spec.ts`, FR + EN)
- Charge `/fr` (puis `/en`), `emulateMedia({ media: 'print' })`.
- Dans `.cv-full-cv-print-root`, ordonne les blocs par position réelle (le print-root réordonne en flex via `order`), mesure l'écart avant chaque titre de section = `top(h2) − bottom(bloc précédent)`.
- Assertion : `max(gaps) − min(gaps) ≤ 4px` (rythme uniforme).

## Preuves
- ✅ **Passe sur `main`** : écarts tous à **20.8px**, spread **0** (inclut le gap avant « Expérience »).
- ✅ **Attrape la régression** : padding réintroduit → gap Expérience **20.8 → 36.8px**, spread 16 > 4 → **échoue**, message pointant « Professional Experience ».
- ✅ **Revert propre** : le commit ne contient **que le test** (diff globals.css vide).

## Gate
`npx playwright test` : **2 passed** · Prettier ✅ · tsc ✅ · next lint ✅.

Complémentaire (pas redondant) des snapshots pixel et du futur gate Argos (0019) : ici c'est une **invariante chiffrée**, robuste, sans image de référence.

> ⚠️ PR-only : ne pas merger tant que le pipeline staging (0013) n'est pas en place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)