### PR TITLE
ci(visual): gate de revue visuelle Argos (sur demande, bloque le merge)

### DIFF
--- a/.github/workflows/visual-review.yml
+++ b/.github/workflows/visual-review.yml
@@ -1,0 +1,48 @@
+# Revue visuelle (Argos) — gate de merge, SUR DEMANDE.
+#
+# Déclenché manuellement (workflow_dispatch) OU en posant le label `visual` sur une PR.
+# NE tourne PAS à chaque commit (coût). Capture les rendus du CV, les envoie à Argos,
+# qui compare à la baseline (main) et poste un check GitHub à approuver/rejeter.
+# Via branch protection (check requis), le squash+merge reste bloqué tant que non validé.
+#
+# ⚠️ PRÉREQUIS (voir VISUAL-REVIEW.md) : projet Argos + app GitHub Argos + secret ARGOS_TOKEN
+# + rendre le check Argos requis en branch protection.
+name: Visual review (Argos)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  visual:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'visual'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright (chromium)
+        run: npx playwright install --with-deps chromium
+
+      - name: Build, start & capture screenshots
+        run: |
+          npm run build
+          npm run start &
+          npx wait-on http://localhost:3000 --timeout 90000
+          node scripts/argos-capture.mjs
+        env:
+          BASE_URL: http://localhost:3000
+
+      - name: Upload to Argos
+        run: npx @argos-ci/cli upload ./screenshots
+        env:
+          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}

--- a/VISUAL-REVIEW.md
+++ b/VISUAL-REVIEW.md
@@ -1,0 +1,33 @@
+# Revue visuelle (Argos) — gate de merge
+
+## But
+
+Un **diff visuel avant/après** du CV, **sur demande**, qui **bloque le merge** tant qu'il
+n'est pas validé. Complète les snapshots pixel composant et l'assertion e2e (fiche 0018).
+
+## Comment ça marche
+
+- **Sur demande** : label `visual` sur une PR, ou « Run workflow » (workflow_dispatch).
+  PAS à chaque commit (coût CI).
+- Le workflow build + sert le CV, capture les rendus (full/short × FR/EN × web/aperçu print,
+  cf. `scripts/argos-capture.mjs`) et les envoie à **Argos**.
+- Argos compare à la **baseline** (main) et poste un **check GitHub** : le diff avant/après
+  est consultable et s'**approuve/rejette** dans l'UI Argos.
+- Via **branch protection** (check requis), le squash+merge reste **bloqué** tant que le
+  diff n'est pas approuvé. La baseline se met à jour au merge sur `main`.
+
+## Mise en place (à faire UNE fois — actions manuelles)
+
+1. Créer le projet sur https://app.argos-ci.com, le lier à ce repo, installer l'app GitHub Argos.
+2. Secret repo (Settings → Secrets and variables → Actions) : `ARGOS_TOKEN` (fourni par Argos).
+3. Branch protection (Settings → Branches → `main`) : rendre le check **Argos** requis pour merger.
+4. (Optionnel) ajuster les routes capturées dans `scripts/argos-capture.mjs`.
+
+## Usage
+
+Sur une PR prête (après la revue de code) : pose le label **`visual`** → le workflow tourne →
+approuve le diff dans Argos → le check passe → le merge est débloqué.
+
+> Le script utilise Playwright (déjà présent) sans importer `@argos-ci` : l'upload passe par
+> `npx @argos-ci/cli` dans le workflow. Si tu préfères l'intégration `@argos-ci/playwright`
+> (screenshots taggés directement dans des specs), installe-la et remplace le script.

--- a/scripts/argos-capture.mjs
+++ b/scripts/argos-capture.mjs
@@ -1,0 +1,44 @@
+// Capture des rendus du CV pour la revue visuelle (Argos).
+// Playwright pur (déjà présent) ; n'importe PAS `@argos-ci` → pas de dépendance
+// sur un package non installé. L'upload se fait via `npx @argos-ci/cli` dans le
+// workflow. Sert le CV local (BASE_URL, défaut http://localhost:3000).
+import { chromium } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+
+const BASE = process.env.BASE_URL || 'http://localhost:3000';
+const OUT = 'screenshots';
+
+// full/short × FR/EN × web/aperçu print — la matrice couverte par le gate.
+const TARGETS = [
+  { name: 'fr-full-web', path: '/fr', print: false },
+  { name: 'fr-full-print', path: '/fr', print: true },
+  { name: 'fr-short-web', path: '/fr/short', print: false },
+  { name: 'fr-short-print', path: '/fr/short', print: true },
+  { name: 'en-full-web', path: '/en', print: false },
+  { name: 'en-full-print', path: '/en', print: true },
+  { name: 'en-short-web', path: '/en/short', print: false },
+  { name: 'en-short-print', path: '/en/short', print: true },
+];
+
+mkdirSync(OUT, { recursive: true });
+
+const browser = await chromium.launch();
+try {
+  for (const t of TARGETS) {
+    const page = await browser.newPage({
+      viewport: { width: 1200, height: 1600 },
+    });
+    if (t.print) await page.emulateMedia({ media: 'print' });
+    await page.goto(`${BASE}${t.path}`, {
+      waitUntil: 'networkidle',
+      timeout: 60000,
+    });
+    await page.waitForTimeout(600);
+    await page.screenshot({ path: `${OUT}/${t.name}.png`, fullPage: true });
+    await page.close();
+  }
+} finally {
+  await browser.close();
+}
+
+console.log(`Captured ${TARGETS.length} screenshots to ${OUT}/`);


### PR DESCRIPTION
Fiche backlog **0019** (P2). Gate de **diff visuel** avant/après du CV qui **bloque le squash+merge** tant que le rendu n'est pas validé.

## Contenu
- `.github/workflows/visual-review.yml` — **sur demande** (label `visual` ou « Run workflow »), pas à chaque commit. Build + sert le CV, capture les rendus, upload Argos.
- `scripts/argos-capture.mjs` — capture Playwright (full/short × FR/EN × web/aperçu print). Playwright pur, sans import `@argos-ci` (upload via `npx @argos-ci/cli`) → ne casse pas le typecheck/lint.
- `VISUAL-REVIEW.md` — le fonctionnement + le pas-à-pas de mise en place.

## Le flux que tu voulais
Après la revue de code → tu poses le label `visual` → diff avant/après dans Argos → tu approuves → le check passe → **branch protection** débloque le squash+merge. Baseline mise à jour au merge sur main.

## ⚠️ À FAIRE PAR TOI (non automatisable / non testable de mon côté)
1. Créer le projet **Argos** (app.argos-ci.com) + installer l'app GitHub Argos.
2. Secret repo : `ARGOS_TOKEN`.
3. Branch protection → rendre le check **Argos** requis pour merger `main`.

> Draft prêt à brancher — je n'ai pas de compte Argos pour le tester. Le script/routes sont ajustables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)