### PR TITLE
fix(cv): écart uniforme avant le bloc de clôture des expériences (impression)

### DIFF
--- a/components/ExperienceClosingBlock.tsx
+++ b/components/ExperienceClosingBlock.tsx
@@ -21,7 +21,11 @@ export default function ExperienceClosingBlock({
   return (
     <div
       id="experience-footer"
-      className="cv-experience-footer mt-4 border-l-4 border-pink-300/50 pl-3 print:mt-2"
+      // Écart au-dessus = MÊME que l'inter-expérience (`space-y-4` = 1rem) dans TOUS
+      // les régimes : ce bloc de clôture se lit comme un « item » de la liste des
+      // expériences. Pas de compression print-only (sinon le PDF colle le bloc à la
+      // dernière expérience alors que l'aperçu/web l'espacent — cf. CLAUDE.md WYSIWYG).
+      className="cv-experience-footer mt-4 border-l-4 border-pink-300/50 pl-3"
     >
       <p className="text-xs text-gray-400 print:text-[10px]">
         <strong className="text-cv-jobs">{moreExperience}</strong>{' '}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -638,9 +638,12 @@ html {
     margin-bottom: 0 !important;
   }
 
-  /* Pied de bloc expériences */
+  /* Pied de bloc expériences.
+     Pas de `margin-top` ici : l'écart au-dessus doit rester celui de l'inter-
+     expérience (`space-y-4` = 1rem, via le `mt-4` de base) dans TOUS les régimes.
+     Le compresser en print (ex. 0.375rem) collait le bloc à la dernière expérience
+     sur le PDF alors que l'aperçu/web l'espaçaient normalement (dérive WYSIWYG). */
   .cv-short-page .cv-experience-footer {
-    margin-top: 0.375rem !important;
     padding-left: 0.5rem !important;
   }
 


### PR DESCRIPTION
## Problème

Le bloc additif en bas des expériences pro (`#experience-footer` — « +N ans d'expérience / autres clients / voir le CV complet ») était **trop collé** à la dernière expérience. Il devrait bénéficier du **même écart que celui entre deux expériences** : on le lit presque comme un item de la liste (même si ce n'est pas une expérience, juste un additif conditionné).

## Cause : dérive **print-only** (WYSIWYG)

À l'écran (web **et** aperçu `?print=1`) l'écart était déjà bon (16px). L'écart n'était compressé qu'à l'**impression** (`@media print`), donc invisible sauf sur le PDF exporté :

- **CV complet** : footer `print:mt-2` (8px) vs inter-expérience `print:space-y-4` (16px).
- **CV court** : `.cv-short-page .cv-experience-footer { margin-top: 0.375rem }` (6px) vs inter-expérience `space-y-4` (16px).

C'est exactement le type de divergence que l'[ADR 0001 / CLAUDE.md](https://github.com/elzinko/my-resume/blob/main/CLAUDE.md) vise à éviter.

## Correctif

Suppression des **deux compressions print** → le bloc hérite du `mt-4` de base (= `space-y-4` = 1rem = 16px) dans **tous les régimes**. Écart uniforme `web == aperçu == PDF`, sans règle print-only spéciale.

## Vérification (Playwright, `media: print` émulée + écran + mobile)

Écart « dernière expérience → bloc de clôture » vs « inter-expérience » :

| Rendu | inter-exp | footer avant | footer après |
|---|---|---|---|
| Complet — web / mobile | 16px | 16px | 16px |
| **Complet — PDF** | 16px | **8px** | **16px** ✅ |
| Court — web / mobile | 16px | 16px | 16px |
| **Court — PDF** | 16px | **6px** | **16px** ✅ |

- Aperçu `?print=1` == PDF (WYSIWYG rétabli).
- **CV court tient toujours sur 1 page A4** : contenu 1020px, ~95px de marge sous la limite imprimable.

Diff : 2 fichiers, +10/-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)