### PR TITLE
style: prettier — reformate 5 fichiers non formatés sur main

### DIFF
--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -60,10 +60,10 @@ export default function HeaderContent({
             // dessus (entre la barre d'outils et le nom). À l'impression, pas de
             // barre d'outils → pt-0 (la marge @page suffit). pb fixe = PDF.
             'pb-8 pt-8 print:pt-0'
-          : 'pb-0 pt-2 max-md:pt-0 md:py-12 print:!py-2'
+          : 'pb-0 pt-2 print:!py-2 max-md:pt-0 md:py-12'
       }`}
     >
-      <div className="flex w-full items-stretch gap-4 md:gap-6 print:gap-4">
+      <div className="flex w-full items-stretch gap-4 print:gap-4 md:gap-6">
         {/* Bloc photo — placé à l'OPPOSÉ du titre : titre à gauche → photo à droite,
             titre à droite (`?headerAlign=right`) → photo à gauche (`order-first`).
             Dès `md:`, même largeur que le bloc texte (`md:flex-1`), avatar centré. */}
@@ -96,7 +96,7 @@ export default function HeaderContent({
                     ageText
                     ? 'h-[72px] w-[72px]'
                     : 'h-16 w-16'
-                  : 'h-20 w-20 md:h-28 md:w-28 lg:h-36 lg:w-36 print:h-28 print:w-28'
+                  : 'h-20 w-20 print:h-28 print:w-28 md:h-28 md:w-28 lg:h-36 lg:w-36'
               }`}
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -128,8 +128,8 @@ export default function HeaderContent({
                 : photoUrl
                 ? // Mobile : text-2xl (24px) → « Thomas Couderc » tient sur 1 ligne
                   // même sur un petit écran (375px). md+ : tailles d'origine.
-                  'text-2xl md:whitespace-nowrap md:text-4xl md:leading-none lg:text-6xl print:text-4xl print:leading-none'
-                : 'text-2xl md:text-5xl md:leading-none lg:text-7xl print:text-5xl print:leading-none'
+                  'text-2xl print:text-4xl print:leading-none md:whitespace-nowrap md:text-4xl md:leading-none lg:text-6xl'
+                : 'text-2xl print:text-5xl print:leading-none md:text-5xl md:leading-none lg:text-7xl'
             }`}
           >
             {name}
@@ -159,14 +159,14 @@ export default function HeaderContent({
                 compactPrint
                   ? // A4 : taille fixe = PDF (text-xs, 12px), pas de bump md:.
                     `${lineGap} text-xs leading-none text-[#22c68d]`
-                  : `${lineGap} text-base leading-snug text-[#22c68d] md:text-xl print:text-base`
+                  : `${lineGap} text-base leading-snug text-[#22c68d] print:text-base md:text-xl`
               }
             >
               {ageText}
             </p>
           ) : null}
           {belowRole ? (
-            <div className="mt-1 hidden w-full md:mt-2 md:block print:mt-2 print:block">
+            <div className="mt-1 hidden w-full print:mt-2 print:block md:mt-2 md:block">
               {belowRole}
             </div>
           ) : null}

--- a/components/HeaderToolbar.tsx
+++ b/components/HeaderToolbar.tsx
@@ -360,7 +360,7 @@ function MobilePrintChooser({
       aria-modal="true"
       aria-label={t.title}
       data-testid="cv-mobile-print-chooser"
-      className="fixed inset-0 z-[120] flex items-end justify-center bg-black/40 p-4 md:hidden print:hidden"
+      className="fixed inset-0 z-[120] flex items-end justify-center bg-black/40 p-4 print:hidden md:hidden"
       onClick={onClose}
     >
       <div
@@ -457,7 +457,7 @@ export default function HeaderToolbar({
   return (
     <>
       <div
-        className="hidden md:flex md:w-full md:flex-row md:items-center md:justify-between print:hidden"
+        className="hidden print:hidden md:flex md:w-full md:flex-row md:items-center md:justify-between"
         data-testid="cv-header-toolbar"
       >
         <Suspense fallback={null}>
@@ -492,7 +492,7 @@ export default function HeaderToolbar({
       />
 
       <div
-        className="fixed inset-x-0 top-0 z-[90] flex items-center gap-2 bg-white/90 px-4 pb-3 backdrop-blur-md supports-[backdrop-filter]:bg-white/80 md:hidden print:hidden"
+        className="fixed inset-x-0 top-0 z-[90] flex items-center gap-2 bg-white/90 px-4 pb-3 backdrop-blur-md supports-[backdrop-filter]:bg-white/80 print:hidden md:hidden"
         style={{
           paddingTop: 'max(0.75rem, env(safe-area-inset-top, 0px))',
         }}

--- a/components/JobDisplay.tsx
+++ b/components/JobDisplay.tsx
@@ -46,7 +46,7 @@ function JobMetaMobileRow({
 
   return (
     <div
-      className={`flex w-full max-w-full items-baseline justify-between gap-x-3 md:hidden print:hidden ${typo}`}
+      className={`flex w-full max-w-full items-baseline justify-between gap-x-3 print:hidden md:hidden ${typo}`}
       data-testid="job-meta-mobile"
     >
       <span className="min-w-0 truncate text-left" data-job-meta="role">
@@ -163,7 +163,7 @@ export default function JobDisplay({
         <div
           className={
             !detailsOpen && hidePillsUntilDetailOpen
-              ? 'max-md:hidden print:!block'
+              ? 'print:!block max-md:hidden'
               : ''
           }
         >
@@ -192,12 +192,12 @@ export default function JobDisplay({
             job.client
           )}
         </span>
-        <span className="min-w-max shrink-0 self-end text-cv-meta font-normal tabular-nums leading-snug text-cv-jobs max-md:hidden print:!inline print:text-xs">
+        <span className="min-w-max shrink-0 self-end text-cv-meta font-normal tabular-nums leading-snug text-cv-jobs print:!inline print:text-xs max-md:hidden">
           {dates}
         </span>
       </div>
       <JobMetaMobileRow roleName={roleName} datesLine={datesStr} />
-      <div className="cv-row-with-side-meta pb-2 max-md:hidden print:flex">
+      <div className="cv-row-with-side-meta pb-2 print:flex max-md:hidden">
         <span className="min-w-0 flex-1 text-cv-meta font-normal leading-snug text-cv-jobs print:text-xs">
           {roleName ?? ''}
           {showRoleAts ? (
@@ -219,7 +219,7 @@ export default function JobDisplay({
       <div
         className={
           !detailsOpen && hidePillsUntilDetailOpen
-            ? 'max-md:hidden print:!block'
+            ? 'print:!block max-md:hidden'
             : ''
         }
       >

--- a/data/cv/experience.json
+++ b/data/cv/experience.json
@@ -478,11 +478,7 @@
       "client": "La Compagnie 1818",
       "startDate": "2008-02-01",
       "roleId": "81994135",
-      "frameworks": [
-        "90601531",
-        "91050008",
-        "91050009"
-      ],
+      "frameworks": ["90601531", "91050008", "91050009"],
       "endDate": "2008-09-01",
       "display": false
     },
@@ -506,11 +502,7 @@
       "client": "Renault SA",
       "startDate": "2005-10-01",
       "roleId": "82089336",
-      "frameworks": [
-        "90601531",
-        "91050002",
-        "91050003"
-      ],
+      "frameworks": ["90601531", "91050002", "91050003"],
       "endDate": "2006-09-01",
       "display": false
     },
@@ -519,10 +511,7 @@
       "client": "CFA SUP 2000",
       "startDate": "2004-09-01",
       "roleId": "81994135",
-      "frameworks": [
-        "90601531",
-        "91050001"
-      ],
+      "frameworks": ["90601531", "91050001"],
       "endDate": "2005-08-01",
       "display": false
     }
@@ -603,10 +592,7 @@
       "name": "shopify-plugin-product-assistant",
       "startDate": "2025-12-01",
       "endDate": null,
-      "frameworks": [
-        "81826170",
-        "82456019"
-      ],
+      "frameworks": ["81826170", "82456019"],
       "bullets": [],
       "tags": [
         {
@@ -621,10 +607,7 @@
       "name": "cop1",
       "startDate": "2026-02-15",
       "endDate": null,
-      "frameworks": [
-        "81826170",
-        "82456019"
-      ],
+      "frameworks": ["81826170", "82456019"],
       "bullets": [],
       "tags": [
         {
@@ -640,10 +623,7 @@
       "name": "iamthelaw",
       "startDate": "2026-02-01",
       "endDate": null,
-      "frameworks": [
-        "81826170",
-        "82456019"
-      ],
+      "frameworks": ["81826170", "82456019"],
       "bullets": [],
       "tags": [
         {
@@ -659,10 +639,7 @@
       "name": "lifefindsaway",
       "startDate": "2026-02-01",
       "endDate": null,
-      "frameworks": [
-        "81826170",
-        "82456019"
-      ],
+      "frameworks": ["81826170", "82456019"],
       "bullets": [],
       "tags": [
         {
@@ -678,10 +655,7 @@
       "name": "realizator",
       "startDate": "2026-01-15",
       "endDate": null,
-      "frameworks": [
-        "81826170",
-        "82456019"
-      ],
+      "frameworks": ["81826170", "82456019"],
       "bullets": [],
       "tags": [
         {
@@ -696,10 +670,7 @@
       "name": "livestreamz",
       "startDate": "2026-01-15",
       "endDate": null,
-      "frameworks": [
-        "81826170",
-        "82456019"
-      ],
+      "frameworks": ["81826170", "82456019"],
       "bullets": [],
       "tags": [
         {
@@ -714,10 +685,7 @@
       "name": "MUTI",
       "startDate": "2026-01-01",
       "endDate": null,
-      "frameworks": [
-        "81826170",
-        "82456019"
-      ],
+      "frameworks": ["81826170", "82456019"],
       "bullets": [],
       "tags": [
         {
@@ -732,10 +700,7 @@
       "name": "byhere",
       "startDate": "2026-03-01",
       "endDate": null,
-      "frameworks": [
-        "81826170",
-        "82456019"
-      ],
+      "frameworks": ["81826170", "82456019"],
       "bullets": [],
       "tags": [
         {

--- a/lib/tech-match-core.ts
+++ b/lib/tech-match-core.ts
@@ -118,7 +118,10 @@ function unionYears(
       start: new Date(i.startDate).getTime(),
       end: (i.endDate ? new Date(i.endDate) : new Date()).getTime(),
     }))
-    .filter((s) => Number.isFinite(s.start) && Number.isFinite(s.end) && s.end >= s.start)
+    .filter(
+      (s) =>
+        Number.isFinite(s.start) && Number.isFinite(s.end) && s.end >= s.start,
+    )
     .sort((a, b) => a.start - b.start);
   if (spans.length === 0) return 0;
   let totalMs = 0;


### PR DESCRIPTION
## Contexte

`npm run prettier:check` (et donc `npm test`) **échouait déjà sur `main`** pour des fichiers non formatés, sans rapport avec une feature. Cette micro-PR applique simplement `npm run prettier`.

## Contenu

**Reformatage pur** (aucun changement de valeur ni de logique — vérifié via `git diff --ignore-all-space`) sur 5 fichiers :
- `components/HeaderContent.tsx`, `components/HeaderToolbar.tsx`, `components/JobDisplay.tsx`
- `data/cv/experience.json` (tableaux repliés sur une ligne, valeurs inchangées)
- `lib/tech-match-core.ts` (retour à la ligne d'un `.filter()` long)

## Anti-conflit (à merger en dernier)

- **`OfferTailoredShell.tsx` volontairement exclu** : il est formaté par la PR **#116** → évite un conflit de merge.
- **Aucun** des 5 fichiers n'est touché par une PR ouverte (#110 / #112 / #114 / #116) → cette PR peut être mergée **en dernier sans complication**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)