### PR TITLE
ci(e2e): cadre le workflow E2E (paths de rendu, skip Dependabot)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,17 @@ name: E2E
 on:
   push:
     branches: ['main']
+  # Sur PR : uniquement quand un fichier pouvant affecter le rendu print change.
+  # → pas de run sur les bumps Dependabot (package.json/lock) ni les PR doc/CI.
   pull_request:
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'styles/**'
+      - 'lib/**'
+      - 'data/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
L'E2E (`print-section-rhythm`) tournait sur **toutes** les PR, y compris les ~5 bumps Dependabot du moment → gaspillage de minutes.

Ajoute un filtre `paths` sur `pull_request` : le job ne se lance **que** si un fichier pouvant affecter le rendu print change (`app/** components/** styles/** lib/** data/** e2e/** playwright.config.ts`). Un bump de dépendance (package.json/lock) ou une PR doc/CI → **E2E non déclenché**.

`push: main` et `workflow_dispatch` inchangés. `cancel-in-progress` déjà en place.

> NB : la CI `build` (nextjs.yml) reste sur les PR Dependabot — c'est voulu (vérifier que le bump ne casse pas le build).