### PR TITLE
feat(dev): nav vers les pages internes sur le CV (hors prod)

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -1,7 +1,8 @@
 import React, { Suspense } from 'react';
-import { i18n } from '../../i18n-config';
+import { i18n, type Locale } from '../../i18n-config';
 import { Analytics } from '@vercel/analytics/react';
 import CvMobilePreviewOverlay from '@/components/CvMobilePreviewOverlay';
+import DevNav from '@/components/DevNav';
 
 export async function generateStaticParams() {
   return i18n.locales.map((locale) => ({ lang: locale }));
@@ -9,8 +10,10 @@ export async function generateStaticParams() {
 
 export default async function RootLayout({
   children,
+  params: { lang },
 }: {
   children: React.ReactNode;
+  params: { lang: Locale };
 }) {
   let enableAnalitycs = true;
   if (process.env.STATIC_DEPLOYMENT) {
@@ -28,6 +31,9 @@ export default async function RootLayout({
       <div className="container mx-auto min-h-screen p-8 print:min-h-0 print:px-8 print:py-0 max-md:px-4 max-md:pb-8 max-md:pt-3">
         <main>{children}</main>
       </div>
+      {/* Nav dev vers les pages internes — hors production uniquement (absente du
+          DOM en prod, même gating que le middleware qui 404 les /dev/* en prod). */}
+      {process.env.VERCEL_ENV !== 'production' && <DevNav lang={lang} />}
       {enableAnalitycs ? <Analytics /> : ''}
     </>
   );

--- a/components/DevNav.tsx
+++ b/components/DevNav.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+/**
+ * Barre de navigation dev DISCRÈTE vers les pages internes du projet.
+ *
+ * Rendue par le layout CV UNIQUEMENT hors production (`VERCEL_ENV !== 'production'`,
+ * décidé côté serveur → absente du DOM en prod). Jamais imprimée (`print:hidden`,
+ * `print-preview:hidden`).
+ *
+ * Le badge d'environnement dépend du hostname (client-only) : LOCAL (pas de
+ * déploiement) / STAGING (staging.elzinko.fr) / PREVIEW (*.vercel.app).
+ */
+type EnvBadge = 'LOCAL' | 'STAGING' | 'PREVIEW';
+
+function resolveEnvBadge(hostname: string): EnvBadge {
+  const localHosts = ['localhost', '127.0.0.1', '0.0.0.0'];
+  if (localHosts.includes(hostname)) return 'LOCAL';
+  if (hostname === 'staging.elzinko.fr') return 'STAGING';
+  return 'PREVIEW';
+}
+
+export default function DevNav({ lang }: { lang: string }) {
+  // Défaut LOCAL → identique au premier rendu client ; corrigé en effect pour
+  // éviter tout mismatch d'hydratation (le hostname n'existe pas au SSR).
+  const [badge, setBadge] = useState<EnvBadge>('LOCAL');
+
+  useEffect(() => {
+    setBadge(resolveEnvBadge(window.location.hostname));
+  }, []);
+
+  const linkClass =
+    'text-slate-300 no-underline hover:text-teal-300 transition-colors';
+
+  return (
+    <nav
+      aria-label="Navigation dev (hors production)"
+      className="fixed bottom-3 right-3 z-50 flex items-center gap-3 rounded-md border border-slate-700 bg-slate-900/90 px-3 py-1.5 text-xs font-medium shadow-lg backdrop-blur-sm print-preview:hidden print:hidden"
+    >
+      <span className="rounded bg-slate-800 px-1.5 py-0.5 font-mono text-[0.65rem] tracking-wide text-teal-300">
+        {badge}
+      </span>
+      <a className={linkClass} href={`/${lang}/dev/renders`}>
+        Renders
+      </a>
+      <a className={linkClass} href={`/${lang}/dev/components`}>
+        Components
+      </a>
+      <a className={linkClass} href="/api/llm-guide">
+        LLM guide
+      </a>
+    </nav>
+  );
+}


### PR DESCRIPTION
Petit panneau **discret** (pill fixe en bas à droite) sur les pages CV, avec des liens vers les pages internes — **visible uniquement hors production**.

## Contenu
- `components/DevNav.tsx` (client) : pill sombre `fixed bottom-3 right-3`, **`print:hidden print-preview:hidden`** (jamais dans le PDF/aperçu). Badge d'env **LOCAL / STAGING / PREVIEW** (via hostname, useEffect → pas de mismatch SSR) + 3 liens : **Renders**, **Components**, **LLM guide**.
- `app/[lang]/layout.tsx` : rendu conditionnel `{process.env.VERCEL_ENV !== 'production' && <DevNav lang={lang} />}` → **absent du DOM en prod**, présent en local/preview/staging (même gating que le middleware #110).

## Gate
Prettier ✅ · tsc ✅ · next lint ✅ · test:unit **169/169**. Vérifié : présent en local (badge LOCAL), hrefs corrects, disparaît en média print ET en aperçu `?print=1`.

> Preview de cette PR → badge **PREVIEW** ; `staging.elzinko.fr` → **STAGING** ; `elzinko.fr` (prod) → nav **absente**.