### PR TITLE
docs(features): backlog — 7 fiches UI (rendu mobile/tablette/print, zoom short)

### DIFF
--- a/features/0008-dev-renders-mobile.md
+++ b/features/0008-dev-renders-mobile.md
@@ -1,0 +1,47 @@
+---
+id: 0008
+title: /dev/renders lisible et utilisable en vue mobile
+type: feature
+priority: P3
+version:
+status: todo
+pr:
+created: 2026-07-02
+---
+
+# 0008 — /dev/renders lisible et utilisable en vue mobile
+
+## Contexte / Problème
+
+`app/[lang]/dev/renders/page.tsx` (dashboard de comparaison des rendus CV : onglets
+`snapshots` / `live` / `compare`) est pensé desktop. Sur mobile, la grille de comparaison
+(iframes réduits, contrôles sticky) n'est pas adaptée.
+
+Peu prioritaire : le contrôle des rendus se fait en web, hors prod. Mais ce serait
+confortable de pouvoir vérifier les previews de PR **depuis un mobile** (ex. relecture
+d'une PR loin du poste).
+
+## Proposition
+
+Rendre `/dev/renders` utilisable sur petit écran, sans casser le desktop :
+
+- Les contrôles (URLs réf/candidat, langue, onglets) passent en pile verticale < md.
+- L'onglet `compare` (3 colonnes Variant × Réf × Cand) devient empilable ou scrollable
+  horizontalement proprement sur mobile.
+- Vérifier que les iframes ne débordent pas (largeur 100 %, scroll interne si besoin).
+
+Outil de dev uniquement → pas de contrainte WYSIWYG CV ; on peut styler librement.
+
+## Critères d'acceptation
+
+- [ ] `/fr/dev/renders` est lisible et navigable sur un viewport 390px (onglets, contrôles).
+- [ ] L'onglet `compare` reste exploitable sur mobile (empilé ou scroll horizontal contrôlé).
+- [ ] Aucun débordement horizontal du body sur mobile.
+- [ ] Desktop inchangé.
+- [ ] Gate locale verte (typecheck/lint/tests).
+
+## Notes / décisions
+
+- Fichier : `app/[lang]/dev/renders/page.tsx` (styles inline, pas de Tailwind — volontaire
+  pour ne pas dépendre du design system du CV).
+- Hors périmètre « rendu CV » (pas de régime print).

--- a/features/0009-espacement-uniforme-sous-domaines.md
+++ b/features/0009-espacement-uniforme-sous-domaines.md
@@ -1,0 +1,58 @@
+---
+id: 0009
+title: Espacement uniforme au-dessus des sous-domaines (Agile == Dev == Ops)
+type: bug
+priority: P1
+version:
+status: todo
+pr:
+created: 2026-07-02
+---
+
+# 0009 — Espacement uniforme au-dessus des sous-domaines (Agile == Dev == Ops)
+
+## Contexte / Problème
+
+Sous la section **Profile**, les sous-domaines **Agile / Dev / Ops** (`components/Domain.tsx`,
+rendus par `app/[lang]/domains.tsx` dans `.cv-domains-grid`) n'ont pas le même espacement
+au-dessus de leur titre selon la position :
+
+- **« Agile »** (1er domaine) est séparé de l'intro Profil par le gap inter-blocs
+  (flex-gap `--cv-section-gap` ≈ 1.3rem) → grand écart.
+- **« Dev » / « Ops »** (empilés en dessous en mobile) ne sont séparés que par le
+  `gap-2` (0.5rem) de `.cv-domains-grid` en `grid-cols-1` (< md) → petit écart.
+
+Résultat visible en **mobile** (cf. screenshot) : « Agile » flotte loin de l'intro, « Dev »
+est collé sous les pastilles d'Agile. L'utilisateur veut **le même espacement au-dessus de
+chaque sous-domaine**, et « plus généralement sur toutes les vues » (rythme intentionnel).
+
+## Proposition
+
+Rendre uniforme l'écart vertical au-dessus de chaque titre de sous-domaine quand ils sont
+empilés (mobile), et garder l'alignement propre en 3 colonnes (tablette/desktop où ils sont
+côte à côte, donc déjà « au même niveau »).
+
+- Piste : augmenter le `gap-y` de `.cv-domains-grid` en `grid-cols-1` (mobile) pour matcher
+  l'écart au-dessus d'« Agile » (plutôt que coller Agile à l'intro) → les 3 blocs deviennent
+  régulièrement espacés.
+- Vérifier que ça ne dégrade pas le rythme en 3 colonnes (md+ : `gap-y-0` conservé) ni
+  l'impression (`print:gap-y-0`, 3 colonnes).
+
+Décision d'ampleur (coller Agile à l'intro vs espacer Dev/Ops comme Agile) : trancher
+visuellement — privilégier un rythme régulier lisible.
+
+## Critères d'acceptation
+
+- [ ] En mobile, l'espace au-dessus de « Agile », « Dev » et « Ops » est visuellement identique.
+- [ ] En tablette/desktop (3 colonnes), les 3 titres démarrent au même niveau (inchangé/OK).
+- [ ] Cohérent dans les 4 rendus (complet-web, complet-print, + aperçu `?print`) — cf.
+      `docs/cv-rendering-review-checklist.md`.
+- [ ] Pas de régression du garde-fou e2e « rythme inter-sections uniforme » (#108/#112).
+- [ ] Gate locale verte + E2E.
+
+## Notes / décisions
+
+- Grille : `.cv-domains-grid` — `styles/globals.css:109-112`.
+- Marges internes des domaines : `components/Domain.tsx` (`mt-2`/`mt-4` desc, `mt-2` pastilles).
+- Lié à [[0012-tablette-premiere-ligne-alignee]] (même zone, alignement tablette) et
+  [[0010-tamiser-couleur-sous-domaines]] (mêmes titres).

--- a/features/0010-tamiser-couleur-sous-domaines.md
+++ b/features/0010-tamiser-couleur-sous-domaines.md
@@ -1,0 +1,54 @@
+---
+id: 0010
+title: Tamiser la couleur des sous-domaines Agile/Dev/Ops (hiérarchie sous Profile)
+type: feature
+priority: P2
+version:
+status: todo
+pr:
+created: 2026-07-02
+---
+
+# 0010 — Tamiser la couleur des sous-domaines Agile/Dev/Ops (hiérarchie sous Profile)
+
+## Contexte / Problème
+
+Les titres des sous-domaines **Agile / Dev / Ops** utilisent `text-blue-400`
+(`components/Domain.tsx:112-114`, `#60a5fa`), un bleu proche/aussi vif que le titre de
+section **Profile** (`SectionHeadingAts` accent bleu, `#4e94f8`). Résultat : on distingue
+mal que Agile/Dev/Ops sont des **sous-parties** de Profile plutôt que des sections sœurs.
+
+L'utilisateur veut **tamiser** (adoucir) la couleur de ces sous-titres pour renforcer la
+hiérarchie visuelle : sous-partie < section.
+
+## Proposition
+
+Choisir une teinte plus douce/désaturée pour les titres de sous-domaines (et cohérente avec
+la barre verticale d'accent `bg-current` + les pastilles `.cv-pill-domain` qui héritent aussi
+du bleu). Options :
+
+1. Baisser l'opacité / la saturation du bleu du titre (ex. `text-blue-400/80`, ou un
+   slate-bleu type `text-slate-400`) — la barre verticale suit (`bg-current`).
+2. Garder la taille (déjà `text-xl` < `text-2xl` du titre Profile) et ne jouer QUE sur la
+   couleur, pour préserver la hiérarchie typographique existante.
+
+Décider si les **pastilles** (`.cv-pill-domain`, `styles/globals.css:563-567`) suivent le
+même tamis ou restent en bleu vif (probablement les garder — elles portent l'accent techno).
+POC couleur d'abord, ajuster au visuel.
+
+## Critères d'acceptation
+
+- [ ] Les titres Agile/Dev/Ops sont visiblement plus doux que le titre « Profile ».
+- [ ] La barre verticale d'accent reste cohérente avec le titre (couleur alignée).
+- [ ] Lisibilité conservée (contraste suffisant) dans les 4 rendus, y compris impression
+      (`print:!text-blue-400` sur les pastilles à réévaluer si on change la teinte).
+- [ ] Cohérent web / aperçu `?print` / PDF — cf. `docs/cv-rendering-review-checklist.md`.
+- [ ] Gate locale verte + E2E.
+
+## Notes / décisions
+
+- Titres : `components/Domain.tsx:112-133` (`titleTypo`, `text-blue-400`).
+- Pastilles : `.cv-pill-domain` — `styles/globals.css:563-567` (dont `print:!text-blue-400`).
+- Envisager de passer par une variable/token de couleur : voir fiche 0003
+  « Design system — CSS variables et tokens ».
+- Lié à [[0009-espacement-uniforme-sous-domaines]] (mêmes titres).

--- a/features/0011-nom-pleine-largeur-mobile.md
+++ b/features/0011-nom-pleine-largeur-mobile.md
@@ -1,0 +1,49 @@
+---
+id: 0011
+title: Nom en pleine largeur sur mobile (pas de photo → agrandir le nom)
+type: feature
+priority: P2
+version:
+status: todo
+pr:
+created: 2026-07-02
+---
+
+# 0011 — Nom en pleine largeur sur mobile (pas de photo → agrandir le nom)
+
+## Contexte / Problème
+
+En vue **mobile**, la photo est masquée (`components/HeaderContent.tsx:77` `max-md:hidden`),
+donc le bloc texte occupe déjà toute la largeur. Mais le **nom** (« Thomas Couderc ») est rendu
+en `text-2xl` (24px, `HeaderContent.tsx:129-132`) — taille choisie pour tenir sur une ligne à
+375px, mais qui laisse beaucoup de blanc à droite. Le nom étant constant et sans photo à côté,
+il devrait **prendre plus de place** (remplir la largeur si possible).
+
+## Proposition
+
+Sur mobile **uniquement** (< md), agrandir le nom pour qu'il remplisse ~la largeur dispo tout
+en restant sur **une seule ligne** :
+
+- Piste robuste : taille de police **fluide** bornée, ex. `text-[clamp(2rem, 12vw, 3rem)]` en
+  `max-md:` (à calibrer pour que « Thomas Couderc » remplisse ~375-430px sans wrapper).
+- Alternative : bump de palier (`text-4xl` en mobile) — plus simple mais moins « pleine largeur ».
+- Ne change RIEN à desktop/print (`md:text-5xl … lg:text-7xl`, `print:text-5xl`) ni au CV court
+  (`compactPrint`, taille fixe A4).
+- Cas photo présente (`?photo=1`) : photo masquée en mobile aussi → traiter pareil OU garder le
+  comportement actuel ; décider (probablement même règle « pleine largeur si pas de photo visible »).
+
+## Critères d'acceptation
+
+- [ ] En mobile (375px et 430px), « Thomas Couderc » est nettement plus grand et remplit ~la
+      largeur, **sans passer sur 2 lignes**.
+- [ ] Desktop (md+), impression et CV court **inchangés**.
+- [ ] Le sous-titre (rôle) et l'âge restent cohérents / lisibles sous le nom agrandi.
+- [ ] Pas de débordement horizontal.
+- [ ] Gate locale verte + E2E.
+
+## Notes / décisions
+
+- Fichier : `components/HeaderContent.tsx:119-136` (`<h1 data-cv-id="fullname">`).
+- Contrainte historique : `text-2xl` retenu pour tenir sur 1 ligne à 375px → toute solution
+  doit préserver ça au plus petit breakpoint.
+- Mobile only → pas d'impact WYSIWYG print (l'impression reste calée sur desktop).

--- a/features/0012-tablette-premiere-ligne-alignee.md
+++ b/features/0012-tablette-premiere-ligne-alignee.md
@@ -1,0 +1,48 @@
+---
+id: 0012
+title: Tablette — titres Agile/Dev/Ops alignés (première ligne au même niveau)
+type: bug
+priority: P2
+version:
+status: todo
+pr:
+created: 2026-07-02
+---
+
+# 0012 — Tablette — titres Agile/Dev/Ops alignés (première ligne au même niveau)
+
+## Contexte / Problème
+
+En **vue tablette** (≥ md = 768px, `.cv-domains-grid` en `grid-cols-3`), les pastilles des
+sous-domaines Agile/Dev/Ops ne tiennent pas sur une seule ligne (elles wrappent). Ce n'est pas
+grave — ça reste lisible. **Mais** comme pour le mobile et les autres vues, l'utilisateur veut
+que **la première ligne (les titres Agile/Dev/Ops) démarre au même niveau** dans les 3 colonnes.
+
+Actuellement `.cv-domains-grid` utilise `md:items-stretch` et chaque `Domain` est un
+`flex flex-col` avec description `flex-1` (pousse les pastilles en bas). Les titres SONT censés
+être en haut (alignés), mais à vérifier en tablette : selon la hauteur d'intro/description, un
+décalage de la première ligne peut apparaître.
+
+## Proposition
+
+Garantir que les 3 titres de sous-domaines s'alignent en haut (première ligne au même Y) en
+tablette et desktop, indépendamment du nombre de lignes de description / de pastilles :
+
+- Vérifier que `items-stretch` + titre en tête de colonne suffit ; sinon aligner explicitement
+  le haut des colonnes (`items-start` sur la rangée des titres) tout en gardant les pastilles
+  alignées en bas via `flex-1` sur la description.
+- Ne pas casser l'alignement bas des pastilles (déjà voulu, cf. `Domain.tsx` commentaires).
+
+## Critères d'acceptation
+
+- [ ] En tablette (~768-1024px), les titres « Agile », « Dev », « Ops » démarrent exactement au
+      même niveau vertical, même si les pastilles wrappent sur 2 lignes.
+- [ ] Les pastilles restent alignées en bas des 3 colonnes (comportement existant conservé).
+- [ ] Desktop et impression inchangés / cohérents (3 colonnes).
+- [ ] Gate locale verte + E2E (vérif Playwright en viewport tablette).
+
+## Notes / décisions
+
+- Grille : `.cv-domains-grid` — `styles/globals.css:109-112`.
+- Composant : `components/Domain.tsx:135-152` (`flex flex-col`, description `flex-1`).
+- Lié à [[0009-espacement-uniforme-sous-domaines]] (même zone, cohérence d'alignement inter-vues).

--- a/features/0013-short-zoom-defaut-100.md
+++ b/features/0013-short-zoom-defaut-100.md
@@ -1,0 +1,49 @@
+---
+id: 0013
+title: /short web — zoom par défaut 100 % (min 75 %, max 150 %)
+type: bug
+priority: P1
+version:
+status: todo
+pr:
+created: 2026-07-02
+---
+
+# 0013 — /short web — zoom par défaut 100 % (min 75 %, max 150 %)
+
+## Contexte / Problème
+
+Sur `/[lang]/short` en web (ex. `https://staging.elzinko.fr/fr/short`), le zoom par défaut
+part à **~184 %** : `CvZoomSlider` applique `fitToWidth()` en vue normale desktop
+(`components/CvZoomSlider.tsx:68`), soit `largeur_dispo / 800`. Sur écran large ça donne
+~1.84 → le CV court s'étale sur toute la largeur.
+
+L'utilisateur veut un **zoom par défaut à 100 %**, avec **min 75 %** et **max 150 %**.
+(Déjà demandé auparavant — probable régression.)
+
+## Proposition
+
+Dans `components/CvZoomSlider.tsx` :
+
+- `MIN` : `0.5` → **`0.75`**
+- `MAX` : `2.5` → **`1.5`**
+- Vue normale desktop (`!printMode`) : appliquer **`1`** au lieu de `fitToWidth()`
+  (ligne 68). Le bouton « % » (fit-to-width) peut rester comme action manuelle, clampé au
+  nouveau [0.75 ; 1.5] — ou être revu si `fitToWidth` n'a plus de sens comme défaut.
+- Vérifier `SCREEN_A4_ZOOM` (0.82) pour l'aperçu `?print=1` : 0.82 ≥ 0.75 → reste dans les
+  bornes, OK. Mobile force déjà `1` (inchangé).
+- Le PDF n'est jamais affecté (`@media print { zoom: 1 !important }`).
+
+## Critères d'acceptation
+
+- [ ] `/fr/short` en web desktop s'ouvre à **100 %** (pas 184 %).
+- [ ] Le curseur borne à **75 % min** et **150 % max**.
+- [ ] Aperçu `?print=1` inchangé (A4 à ~0.82) et dans les bornes.
+- [ ] Mobile inchangé (zoom 1, curseur masqué).
+- [ ] PDF inchangé (zoom neutralisé).
+- [ ] Gate locale verte + E2E.
+
+## Notes / décisions
+
+- Fichier : `components/CvZoomSlider.tsx:12-13` (MIN/MAX) et `:64-68` (valeur par défaut).
+- Vérifier les tests e2e existants qui liraient un % de zoom par défaut.

--- a/features/0014-espacement-age-profile-web-print.md
+++ b/features/0014-espacement-age-profile-web-print.md
@@ -1,0 +1,60 @@
+---
+id: 0014
+title: Espacement âge→Profile identique web/impression (WYSIWYG print == web desktop)
+type: bug
+priority: P1
+version:
+status: todo
+pr:
+created: 2026-07-02
+---
+
+# 0014 — Espacement âge→Profile identique web/impression (WYSIWYG print == web desktop)
+
+## Contexte / Problème
+
+En **web** (CV complet desktop), l'espace entre le bloc en-tête (nom/rôle/**âge**) et la
+section **Profile** est agréable. En **impression**, la sensation diffère : le bloc du haut
+est **trop rapproché** de « Profile » (cf. screenshot 2). Or, sur l'impression du CV complet,
+il reste de la place en bas → rien ne justifie ce resserrement.
+
+Cause : l'en-tête (`Headers` → `HeaderContent`) est **hors** de `.cv-full-cv-print-root`. Son
+espacement bas dépend de son propre padding : `md:py-12` (**3rem**) en web desktop, mais
+`print:!py-2` (**0.5rem**) en impression (`components/HeaderContent.tsx:63`). D'où la divergence.
+
+**Question de l'utilisateur** : « je pensais que les versions impression devaient être
+strictement identiques aux versions web desktop » → **oui**, c'est l'invariant #1 de
+`CLAUDE.md` (WYSIWYG : `web == aperçu == PDF`, mobile excepté). Donc c'est un vrai bug de
+cohérence : l'impression doit retrouver le rythme du web desktop.
+
+## Proposition
+
+Aligner l'espacement en-tête → Profile de l'impression (et de l'aperçu `?print`) sur celui du
+web desktop (que l'utilisateur valide) :
+
+- Rapprocher le padding bas de l'en-tête en print du `md:py-12` web (ex. supprimer/relever le
+  `print:!py-2` pour l'en-tête complet — **pas** le CV court `compactPrint` qui reste calé A4).
+- Vérifier l'aperçu `.cv-print-preview` en parallèle (même règle, pas d'orpheline — invariant #2).
+- Profiter de la place en bas de la page 1 (le complet a de la marge).
+
+⚠️ Zone sensible : rythme d'impression calibré (PR #108/#112/#115) + garde-fou e2e
+« rythme inter-sections uniforme ». Le gap en-tête→Profile est un cas à part (l'en-tête n'est
+pas une `<section>`), mais **revérifier** que le garde-fou et la pagination (rester sur le bon
+nb de pages) ne cassent pas.
+
+## Critères d'acceptation
+
+- [ ] L'écart âge → « Profile » est visuellement le **même** en web desktop, aperçu `?print` et PDF.
+- [ ] L'impression du CV complet ne déborde pas / garde une pagination correcte (place en bas OK).
+- [ ] Règle appliquée à la fois `@media print` ET `.cv-print-preview` (pas d'orpheline).
+- [ ] CV court (`compactPrint`) inchangé (reste calé A4).
+- [ ] Garde-fou e2e « rythme inter-sections » (#108/#112) toujours vert.
+- [ ] Gate locale verte + E2E, vérif des 4 rendus (`docs/cv-rendering-review-checklist.md`).
+
+## Notes / décisions
+
+- Padding en-tête : `components/HeaderContent.tsx:55-64` (`pb-0 pt-2 print:!py-2 max-md:pt-0 md:py-12`).
+- Structure : `Headers` hors `.cv-full-cv-print-root` (`components/OfferTailoredShell.tsx:102-112`).
+- Tokens inter-sections : `styles/globals.css:5-86` (`--cv-section-gap`, overrides print/preview).
+- Formalise/valide l'invariant WYSIWYG côté en-tête → penser à documenter si on ajuste
+  (ADR `docs/adr/0001-cv-rendering-regimes.md`).

--- a/features/0015-impression-toutes-pastilles-experiences.md
+++ b/features/0015-impression-toutes-pastilles-experiences.md
@@ -1,0 +1,48 @@
+---
+id: 0015
+title: Impression CV complet — afficher toutes les pastilles techno des expériences
+type: bug
+priority: P1
+version:
+status: todo
+pr:
+created: 2026-07-03
+---
+
+# 0015 — Impression CV complet — afficher toutes les pastilles techno des expériences
+
+## Contexte / Problème
+
+En **impression du CV complet** (aperçu `?print` et PDF), les pastilles techno des
+expériences sont **tronquées** : plafonnées à 10 + « … » (le même cap qu'à l'écran).
+Le catalogue techno d'une mission n'est donc pas affiché en entier (cf. screenshot
+Médiapost : `java 5 · maven 2 · git · tomcat 5 · jenkins · sybase · jasper report ·
+selenium · scrum · tdd · …`). Certaines missions ont bien plus de technos (SNCF 20,
+une mission 52).
+
+Cause : `components/JobFrameworkPills.tsx` plafonne à `MAX_VISIBLE_WHEN_COLLAPSED = 10`
+en impression **pour le CV long comme pour le court**.
+
+## Proposition
+
+En régime impression du **CV LONG** (`!compact`), afficher `frameworks.length` pastilles
+(catalogue complet), sur plusieurs lignes (le conteneur non-compact est déjà `flex-wrap`
+/ `print:max-h-none`). Régime impression détecté par le state `printing` (⌘P via
+`beforeprint`) **ET** la classe `.cv-print-preview` sur `<html>` (aperçu `?print`) pour
+couvrir aperçu + PDF (WYSIWYG). CV court (`compact`) inchangé : plafond 10 (tient sur 1
+page A4).
+
+## Critères d'acceptation
+
+- [ ] Impression CV complet (aperçu `?print` ET PDF) : **toutes** les pastilles de chaque
+      expérience, aucune troncature ni « … ».
+- [ ] Écran CV complet : fit 1 ligne + bouton « … » (inchangé).
+- [ ] CV court écran ET impression : plafond 10 (inchangé — 1 page A4).
+- [ ] Rythme inter-sections d'impression toujours uniforme (garde-fou `print-section-rhythm`).
+- [ ] Gate locale verte.
+
+## Notes / décisions
+
+- Fichier : `components/JobFrameworkPills.tsx` (state `printing`, cap `MAX_VISIBLE_WHEN_COLLAPSED`).
+- Implémenté dans la PR #126 (vérifié Playwright + PDF réel : Médiapost 12, SNCF 20 sur
+  3 lignes ; écran et short inchangés ; rythme spread 0.0px).

--- a/features/0016-dev-renders-compare-scroll.md
+++ b/features/0016-dev-renders-compare-scroll.md
@@ -1,0 +1,38 @@
+---
+id: 0016
+title: /dev/renders — certains CV ne scrollent pas dans les cellules de comparaison
+type: bug
+priority: P3
+version:
+status: todo
+pr:
+created: 2026-07-03
+---
+
+# 0016 — /dev/renders — certains CV ne scrollent pas dans les cellules de comparaison
+
+## Contexte / Problème
+
+Sur `/dev/renders`, onglet **Comparer**, certains CV ne se laissent pas scroller dans
+leur cellule (iframe réduit / détaillé) → on ne peut pas voir tout le contenu du rendu.
+Observé en marge de la PR #125 (mise au mobile de /dev/renders). « On verra plus tard »
+(outil de dev, hors prod).
+
+## Proposition
+
+Diagnostiquer pourquoi le scroll est bloqué dans certaines cellules (probablement
+`overflow: hidden` sur le conteneur borné + iframe mis à l'échelle par `transform:
+scale()` qui ne propage pas le scroll, ou hauteur d'iframe insuffisante). Permettre un
+scroll interne fiable (ou un clic « ouvrir en grand » systématique).
+
+## Critères d'acceptation
+
+- [ ] Dans l'onglet Comparer, chaque cellule (réduite ET détaillée) permet de voir tout
+      le rendu (scroll interne ou ouverture pleine taille).
+- [ ] Pas de régression desktop/mobile du reste de /dev/renders.
+
+## Notes / décisions
+
+- Fichier : `app/[lang]/dev/renders/page.tsx` (CompareCell / LiveCard, `COMPARE_CELL_HEIGHT`,
+  `transform: scale()`, `overflow: hidden`).
+- Outil de dev uniquement. Lié à [[0008-dev-renders-mobile]] et [[0017-dev-renders-compare-nav]].

--- a/features/0017-dev-renders-compare-nav.md
+++ b/features/0017-dev-renders-compare-nav.md
@@ -1,0 +1,37 @@
+---
+id: 0017
+title: /dev/renders — navigation rapide (onglets/arborescence) pour les comparaisons
+type: feature
+priority: P3
+version:
+status: todo
+pr:
+created: 2026-07-03
+---
+
+# 0017 — /dev/renders — navigation rapide (onglets/arborescence) pour les comparaisons
+
+## Contexte / Problème
+
+Sur `/dev/renders`, onglet **Comparer**, il faut scroller beaucoup pour parcourir toutes
+les variantes (short/full × langue × screen/mobile/print/pdf) réf ↔ candidat. C'est long
+et fastidieux d'aller à une comparaison précise. Idée soulevée en marge de la PR #125 :
+un système d'**onglets** ou une **arborescence** pour accéder plus vite à une comparaison
+donnée. « On verra après » (outil de dev, hors prod).
+
+## Proposition
+
+Ajouter une navigation secondaire dans l'onglet Comparer : sélecteur/arborescence
+(variante → langue → medium) ou sous-onglets, pour sauter directement à une comparaison
+sans scroller toute la matrice. Garder le tout aligné avec la mise au mobile (0008).
+
+## Critères d'acceptation
+
+- [ ] On peut atteindre une comparaison précise (ex. « full · FR · print-preview ») en
+      un ou deux clics, sans scroller toute la page.
+- [ ] Fonctionne desktop ET mobile.
+
+## Notes / décisions
+
+- Fichier : `app/[lang]/dev/renders/page.tsx` (onglet compare, `compareRows()`).
+- Outil de dev uniquement. Lié à [[0008-dev-renders-mobile]] et [[0016-dev-renders-compare-scroll]].

--- a/features/README.md
+++ b/features/README.md
@@ -11,22 +11,24 @@ Dernière mise à jour : 2026-07-03
 
 ## Actives (triées par priorité)
 
-| #    | Titre                                                               | Type     | Prio | Statut  | PR  |
-| ---- | ------------------------------------------------------------------- | -------- | ---- | ------- | --- |
-| 0009 | Espacement uniforme au-dessus des sous-domaines (Agile==Dev==Ops)   | bug      | P1   | 🔴 todo |     |
-| 0013 | /short web — zoom par défaut 100 % (min 75 %, max 150 %)            | bug      | P1   | 🔴 todo |     |
-| 0014 | Espacement âge→Profile identique web/impression (WYSIWYG)           | bug      | P1   | 🔴 todo |     |
-| 0015 | Impression CV complet — toutes les pastilles techno des expériences | bug      | P1   | 🔴 todo |     |
-| 0002 | Loisirs — bascule inline / 2 lignes via `?entriesLayout`            | feature  | P2   | 🔴 todo |     |
-| 0003 | Design system — CSS variables et tokens                             | refactor | P2   | 🔴 todo |     |
-| 0006 | Migration Next.js 14 → 15+/16                                       | chore    | P2   | 🔴 todo |     |
-| 0010 | Tamiser la couleur des sous-domaines Agile/Dev/Ops                  | feature  | P2   | 🔴 todo |     |
-| 0011 | Nom en pleine largeur sur mobile (pas de photo)                     | feature  | P2   | 🔴 todo |     |
-| 0012 | Tablette — titres Agile/Dev/Ops alignés (1ʳᵉ ligne au même niveau)  | bug      | P2   | 🔴 todo |     |
-| 0004 | Data layer découplée (bundle → cv/tech-catalog/locales)             | refactor | P3   | 🔴 todo |     |
-| 0005 | Primitives React réutilisables                                      | refactor | P3   | 🔴 todo |     |
-| 0007 | Retirer `?print` / `FullCvPrintPreviewEffect` résiduels             | refactor | P3   | 🔴 todo |     |
-| 0008 | /dev/renders lisible et utilisable en vue mobile                    | feature  | P3   | 🔴 todo |     |
+| #    | Titre                                                                | Type     | Prio | Statut  | PR  |
+| ---- | -------------------------------------------------------------------- | -------- | ---- | ------- | --- |
+| 0009 | Espacement uniforme au-dessus des sous-domaines (Agile==Dev==Ops)    | bug      | P1   | 🔴 todo |     |
+| 0013 | /short web — zoom par défaut 100 % (min 75 %, max 150 %)             | bug      | P1   | 🔴 todo |     |
+| 0014 | Espacement âge→Profile identique web/impression (WYSIWYG)            | bug      | P1   | 🔴 todo |     |
+| 0015 | Impression CV complet — toutes les pastilles techno des expériences  | bug      | P1   | 🔴 todo |     |
+| 0002 | Loisirs — bascule inline / 2 lignes via `?entriesLayout`             | feature  | P2   | 🔴 todo |     |
+| 0003 | Design system — CSS variables et tokens                              | refactor | P2   | 🔴 todo |     |
+| 0006 | Migration Next.js 14 → 15+/16                                        | chore    | P2   | 🔴 todo |     |
+| 0010 | Tamiser la couleur des sous-domaines Agile/Dev/Ops                   | feature  | P2   | 🔴 todo |     |
+| 0011 | Nom en pleine largeur sur mobile (pas de photo)                      | feature  | P2   | 🔴 todo |     |
+| 0012 | Tablette — titres Agile/Dev/Ops alignés (1ʳᵉ ligne au même niveau)   | bug      | P2   | 🔴 todo |     |
+| 0004 | Data layer découplée (bundle → cv/tech-catalog/locales)              | refactor | P3   | 🔴 todo |     |
+| 0005 | Primitives React réutilisables                                       | refactor | P3   | 🔴 todo |     |
+| 0007 | Retirer `?print` / `FullCvPrintPreviewEffect` résiduels              | refactor | P3   | 🔴 todo |     |
+| 0008 | /dev/renders lisible et utilisable en vue mobile                     | feature  | P3   | 🔴 todo |     |
+| 0016 | /dev/renders — scroll bloqué dans certaines cellules de comparaison  | bug      | P3   | 🔴 todo |     |
+| 0017 | /dev/renders — navigation rapide (onglets/arborescence) comparaisons | feature  | P3   | 🔴 todo |     |
 
 ## Livré (`done/`)
 

--- a/features/README.md
+++ b/features/README.md
@@ -4,26 +4,31 @@ Source de vérité = le front-matter de chaque fiche `features/NNNN-slug.md`. Ce
 **régénéré** depuis les fiches (ne pas l'éditer à la main). Fiches livrées → `features/done/`.
 
 Règles : 1 PR par feature, squash-merge quand la CI est verte. Priorités P0 (urgent) → P3.
-Statuts : 🔴 todo · 🟠 in-progress · ⛔ blocked · ✅ shipped.
+Statuts : 🔴 todo · 🟠 in-progress · ⛔ blocked · ✅ shipped. Rendu CV : respecter les
+invariants de `CLAUDE.md` et la checklist `docs/cv-rendering-review-checklist.md`.
 
 Dernière mise à jour : 2026-07-02
 
 ## Actives (triées par priorité)
 
-| #    | Titre                                                    | Type     | Prio | Statut  | PR  |
-| ---- | -------------------------------------------------------- | -------- | ---- | ------- | --- |
-| 0002 | Loisirs — bascule inline / 2 lignes via `?entriesLayout` | feature  | P2   | 🔴 todo |     |
-| 0003 | Design system — CSS variables et tokens                  | refactor | P2   | 🔴 todo |     |
-| 0006 | Migration Next.js 14 → 15+/16                            | chore    | P2   | 🔴 todo |     |
-| 0004 | Data layer découplée (bundle → cv/tech-catalog/locales)  | refactor | P3   | 🔴 todo |     |
-| 0005 | Primitives React réutilisables                           | refactor | P3   | 🔴 todo |     |
-| 0007 | Retirer `?print` / `FullCvPrintPreviewEffect` résiduels  | refactor | P3   | 🔴 todo |     |
+| #    | Titre                                                              | Type     | Prio | Statut  | PR  |
+| ---- | ------------------------------------------------------------------ | -------- | ---- | ------- | --- |
+| 0009 | Espacement uniforme au-dessus des sous-domaines (Agile==Dev==Ops)  | bug      | P1   | 🔴 todo |     |
+| 0013 | /short web — zoom par défaut 100 % (min 75 %, max 150 %)           | bug      | P1   | 🔴 todo |     |
+| 0014 | Espacement âge→Profile identique web/impression (WYSIWYG)          | bug      | P1   | 🔴 todo |     |
+| 0002 | Loisirs — bascule inline / 2 lignes via `?entriesLayout`           | feature  | P2   | 🔴 todo |     |
+| 0003 | Design system — CSS variables et tokens                            | refactor | P2   | 🔴 todo |     |
+| 0006 | Migration Next.js 14 → 15+/16                                      | chore    | P2   | 🔴 todo |     |
+| 0010 | Tamiser la couleur des sous-domaines Agile/Dev/Ops                 | feature  | P2   | 🔴 todo |     |
+| 0011 | Nom en pleine largeur sur mobile (pas de photo)                    | feature  | P2   | 🔴 todo |     |
+| 0012 | Tablette — titres Agile/Dev/Ops alignés (1ʳᵉ ligne au même niveau) | bug      | P2   | 🔴 todo |     |
+| 0004 | Data layer découplée (bundle → cv/tech-catalog/locales)            | refactor | P3   | 🔴 todo |     |
+| 0005 | Primitives React réutilisables                                     | refactor | P3   | 🔴 todo |     |
+| 0007 | Retirer `?print` / `FullCvPrintPreviewEffect` résiduels            | refactor | P3   | 🔴 todo |     |
+| 0008 | /dev/renders lisible et utilisable en vue mobile                   | feature  | P3   | 🔴 todo |     |
 
 ## Livré (`done/`)
 
 | #    | Titre                         | Type     | Prio | Statut     | PR  |
 | ---- | ----------------------------- | -------- | ---- | ---------- | --- |
 | 0001 | Unification layout CV complet | refactor | P1   | ✅ shipped |     |
-
-> Priorités **proposées** à la migration depuis `ROADMAP.md` — à réajuster (éditer le
-> front-matter des fiches puis régénérer cet index).

--- a/features/README.md
+++ b/features/README.md
@@ -7,25 +7,26 @@ Règles : 1 PR par feature, squash-merge quand la CI est verte. Priorités P0 (u
 Statuts : 🔴 todo · 🟠 in-progress · ⛔ blocked · ✅ shipped. Rendu CV : respecter les
 invariants de `CLAUDE.md` et la checklist `docs/cv-rendering-review-checklist.md`.
 
-Dernière mise à jour : 2026-07-02
+Dernière mise à jour : 2026-07-03
 
 ## Actives (triées par priorité)
 
-| #    | Titre                                                              | Type     | Prio | Statut  | PR  |
-| ---- | ------------------------------------------------------------------ | -------- | ---- | ------- | --- |
-| 0009 | Espacement uniforme au-dessus des sous-domaines (Agile==Dev==Ops)  | bug      | P1   | 🔴 todo |     |
-| 0013 | /short web — zoom par défaut 100 % (min 75 %, max 150 %)           | bug      | P1   | 🔴 todo |     |
-| 0014 | Espacement âge→Profile identique web/impression (WYSIWYG)          | bug      | P1   | 🔴 todo |     |
-| 0002 | Loisirs — bascule inline / 2 lignes via `?entriesLayout`           | feature  | P2   | 🔴 todo |     |
-| 0003 | Design system — CSS variables et tokens                            | refactor | P2   | 🔴 todo |     |
-| 0006 | Migration Next.js 14 → 15+/16                                      | chore    | P2   | 🔴 todo |     |
-| 0010 | Tamiser la couleur des sous-domaines Agile/Dev/Ops                 | feature  | P2   | 🔴 todo |     |
-| 0011 | Nom en pleine largeur sur mobile (pas de photo)                    | feature  | P2   | 🔴 todo |     |
-| 0012 | Tablette — titres Agile/Dev/Ops alignés (1ʳᵉ ligne au même niveau) | bug      | P2   | 🔴 todo |     |
-| 0004 | Data layer découplée (bundle → cv/tech-catalog/locales)            | refactor | P3   | 🔴 todo |     |
-| 0005 | Primitives React réutilisables                                     | refactor | P3   | 🔴 todo |     |
-| 0007 | Retirer `?print` / `FullCvPrintPreviewEffect` résiduels            | refactor | P3   | 🔴 todo |     |
-| 0008 | /dev/renders lisible et utilisable en vue mobile                   | feature  | P3   | 🔴 todo |     |
+| #    | Titre                                                               | Type     | Prio | Statut  | PR  |
+| ---- | ------------------------------------------------------------------- | -------- | ---- | ------- | --- |
+| 0009 | Espacement uniforme au-dessus des sous-domaines (Agile==Dev==Ops)   | bug      | P1   | 🔴 todo |     |
+| 0013 | /short web — zoom par défaut 100 % (min 75 %, max 150 %)            | bug      | P1   | 🔴 todo |     |
+| 0014 | Espacement âge→Profile identique web/impression (WYSIWYG)           | bug      | P1   | 🔴 todo |     |
+| 0015 | Impression CV complet — toutes les pastilles techno des expériences | bug      | P1   | 🔴 todo |     |
+| 0002 | Loisirs — bascule inline / 2 lignes via `?entriesLayout`            | feature  | P2   | 🔴 todo |     |
+| 0003 | Design system — CSS variables et tokens                             | refactor | P2   | 🔴 todo |     |
+| 0006 | Migration Next.js 14 → 15+/16                                       | chore    | P2   | 🔴 todo |     |
+| 0010 | Tamiser la couleur des sous-domaines Agile/Dev/Ops                  | feature  | P2   | 🔴 todo |     |
+| 0011 | Nom en pleine largeur sur mobile (pas de photo)                     | feature  | P2   | 🔴 todo |     |
+| 0012 | Tablette — titres Agile/Dev/Ops alignés (1ʳᵉ ligne au même niveau)  | bug      | P2   | 🔴 todo |     |
+| 0004 | Data layer découplée (bundle → cv/tech-catalog/locales)             | refactor | P3   | 🔴 todo |     |
+| 0005 | Primitives React réutilisables                                      | refactor | P3   | 🔴 todo |     |
+| 0007 | Retirer `?print` / `FullCvPrintPreviewEffect` résiduels             | refactor | P3   | 🔴 todo |     |
+| 0008 | /dev/renders lisible et utilisable en vue mobile                    | feature  | P3   | 🔴 todo |     |
 
 ## Livré (`done/`)
 


### PR DESCRIPTION
## Contexte

Capture au **backlog par fiches** (`features/`) les 7 demandes UI du CV formulées via
`/ezk-backlog add`. Numérotées **0008–0014** (0001–0007 déjà pris par la migration
ROADMAP→features de #120). Index régénéré, trié par priorité.

## Fiches ajoutées

| #    | Prio | Titre |
| ---- | ---- | ----- |
| 0009 | P1   | Espacement uniforme au-dessus des sous-domaines (Agile==Dev==Ops) |
| 0013 | P1   | /short web — zoom par défaut 100 % (min 75 % / max 150 %) |
| 0014 | P1   | Espacement âge→Profile identique web/impression (WYSIWYG) |
| 0010 | P2   | Tamiser la couleur des sous-domaines Agile/Dev/Ops |
| 0011 | P2   | Nom en pleine largeur sur mobile (pas de photo) |
| 0012 | P2   | Tablette — titres Agile/Dev/Ops alignés (1ʳᵉ ligne au même niveau) |
| 0008 | P3   | /dev/renders lisible et utilisable en vue mobile |

## Implémentation

Livrée dans des PRs dédiées, regroupées par zone :

- **Sous-domaines Profile** (`Domain.tsx`, `.cv-domains-grid`) → 0009 + 0010 + 0012
- **En-tête** (`HeaderContent.tsx`) → 0011 + 0014
- **Zoom /short** (`CvZoomSlider.tsx`) → 0013
- **/dev/renders mobile** → 0008

Les fiches passeront en `done/` au fur et à mesure des merges.

Docs-only, pas de changement de rendu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)