### PR TITLE
fix(cv): en-tête — nom pleine largeur mobile + écart âge→Profile en impression

### DIFF
--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -60,7 +60,12 @@ export default function HeaderContent({
             // dessus (entre la barre d'outils et le nom). À l'impression, pas de
             // barre d'outils → pt-0 (la marge @page suffit). pb fixe = PDF.
             'pb-8 pt-8 print:pt-0'
-          : 'pb-0 pt-2 print:!py-2 max-md:pt-0 md:py-12'
+          : // Impression : on aligne l'écart en-tête → Profile sur le web desktop
+            // (WYSIWYG, invariant #1). Le web desktop a `md:py-12` (3rem) sous l'âge ;
+            // l'impression utilisait `print:!py-2` (0.5rem) → bloc du haut collé à
+            // Profile. On rétablit `pb-12` en print (le haut reste `pt-2` : pas de barre
+            // d'outils en PDF, la marge @page suffit → on n'ajoute pas d'air en haut).
+            'pb-0 pt-2 print:!pb-12 print:!pt-2 max-md:pt-0 md:py-12'
       }`}
     >
       <div className="flex w-full items-stretch gap-4 print:gap-4 md:gap-6">
@@ -126,10 +131,11 @@ export default function HeaderContent({
                   // leading-tight de base partagé avec le CV complet.
                   'text-3xl !leading-none'
                 : photoUrl
-                ? // Mobile : text-2xl (24px) → « Thomas Couderc » tient sur 1 ligne
-                  // même sur un petit écran (375px). md+ : tailles d'origine.
-                  'text-2xl print:text-4xl print:leading-none md:whitespace-nowrap md:text-4xl md:leading-none lg:text-6xl'
-                : 'text-2xl print:text-5xl print:leading-none md:text-5xl md:leading-none lg:text-7xl'
+                ? // Mobile : nom FLUIDE qui remplit ~la largeur dispo (pas de photo <md
+                  // → toute la largeur pour le nom), borné pour rester sur 1 ligne à 375px
+                  // et ne pas dépasser la taille md (pas de saut à 768px). md+ : tailles d'origine.
+                  'text-[clamp(1.75rem,10.2vw,2.75rem)] print:text-4xl print:leading-none md:whitespace-nowrap md:text-4xl md:leading-none lg:text-6xl'
+                : 'text-[clamp(1.75rem,10.2vw,2.75rem)] print:text-5xl print:leading-none md:text-5xl md:leading-none lg:text-7xl'
             }`}
           >
             {name}


### PR DESCRIPTION
Deux fiches sur l'en-tête (nom / rôle / âge).

## 0011 — Nom en pleine largeur sur mobile (`HeaderContent.tsx`)
Sur mobile la photo est masquée → le bloc texte occupe toute la largeur, mais le nom
restait en `text-2xl` (24px) avec beaucoup de blanc à droite. Il passe à une taille
**fluide** `text-[clamp(1.75rem,10.2vw,2.75rem)]` : il remplit ~la largeur tout en
restant sur **1 ligne**. Borné à 2.75rem pour ne pas dépasser la taille `md` (aucun saut
en franchissant 768px). Desktop / impression / CV court **inchangés** (les variantes
`md:` / `lg:` / `print:` surchargent la base).

| Largeur | Taille nom | Remplissage | Lignes |
| --- | --- | --- | --- |
| 320px | 32.6px | 98 % | 1 |
| 360px | 37px | 99 % | 1 |
| 375px | 38px | 98 % | 1 |
| 430px | 44px (cap) | 94 % | 1 |

## 0014 — Écart âge→Profile identique web/impression (WYSIWYG, invariant #1)
Le bloc en-tête était **collé** à « Profile » en impression : l'en-tête avait
`print:!py-2` (0.5rem) alors que le web desktop respire avec `md:py-12` (3rem). On
rétablit **`print:!pb-12`** (padding-bas 48px = **exactement** le web desktop). Le haut
reste `pt-2` (pas de barre d'outils en PDF, la marge `@page` suffit — inutile d'ajouter
de l'air en haut et de risquer un débordement).

| Régime | padding-bottom en-tête | écart âge→Profile |
| --- | --- | --- |
| Web desktop | 48px | 68px |
| Impression **avant** | 8px | ~16px (collé) |
| Impression **après** | **48px** | **56px** (généreux) |

## Vérification (Playwright + PDF réel `page.pdf`)
- Nom : 1 ligne sans débordement à 320 / 360 / 375 / 430px ; desktop/print inchangés.
- Impression : PDF réel généré → écart âge→Profile généreux, page 1 garde de la place
  en bas (pas de débordement).
- **Garde-fou CI `print-section-rhythm` : spread 0.0px** (l'en-tête est hors de
  `.cv-full-cv-print-root`, les écarts inter-sections restent identiques).
- CV court (`compactPrint`) : branche non touchée.

Fiches 0011, 0014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)