### PR TITLE
fix(cv): barre dev + zoom en haut (header pleine largeur) + stables au scroll

### DIFF
--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -21,6 +21,9 @@ export default async function RootLayout({
       enableAnalitycs = false;
     }
   }
+  // Hors production : barre de nav dev EN HAUT (pleine largeur, desktop) → on réserve
+  // la hauteur en haut du contenu pour ne pas la recouvrir (mobile : barre en bas).
+  const isDev = process.env.VERCEL_ENV !== 'production';
   return (
     <>
       {process.env.NODE_ENV === 'development' ? (
@@ -28,12 +31,21 @@ export default async function RootLayout({
           <CvMobilePreviewOverlay />
         </Suspense>
       ) : null}
+      {/* Réserve la hauteur de la barre dev (desktop) → le contenu démarre dessous.
+          Écran uniquement : masqué en impression ET en aperçu `?print` (barre cachée
+          là), donc AUCUN impact sur le PDF / l'aperçu. Mobile : barre dev en bas. */}
+      {isDev ? (
+        <div
+          aria-hidden
+          className="hidden h-4 shrink-0 print-preview:hidden print:hidden md:block"
+        />
+      ) : null}
       <div className="container mx-auto min-h-screen p-8 print:min-h-0 print:px-8 print:py-0 max-md:px-4 max-md:pb-8 max-md:pt-3">
         <main>{children}</main>
       </div>
       {/* Nav dev vers les pages internes — hors production uniquement (absente du
           DOM en prod, même gating que le middleware qui 404 les /dev/* en prod). */}
-      {process.env.VERCEL_ENV !== 'production' && <DevNav lang={lang} />}
+      {isDev && <DevNav lang={lang} />}
       {enableAnalitycs ? <Analytics /> : ''}
     </>
   );

--- a/components/CvZoomSlider.tsx
+++ b/components/CvZoomSlider.tsx
@@ -77,7 +77,7 @@ export default function CvZoomSlider() {
 
   return (
     <div
-      className="fixed bottom-4 right-4 z-[200] hidden items-center gap-2 rounded-full border border-slate-300/70 bg-white/90 px-3 py-1.5 text-xs text-slate-600 shadow-md backdrop-blur supports-[backdrop-filter]:bg-white/70 print:hidden md:flex"
+      className="fixed right-3 top-1.5 z-[120] hidden items-center gap-2 rounded-full border border-slate-300/70 bg-white/90 px-3 py-1.5 text-xs text-slate-600 shadow-md backdrop-blur supports-[backdrop-filter]:bg-white/70 print:hidden md:flex"
       data-testid="cv-zoom-slider"
     >
       <span className="select-none font-medium">Zoom</span>

--- a/components/DevNav.tsx
+++ b/components/DevNav.tsx
@@ -36,7 +36,10 @@ export default function DevNav({ lang }: { lang: string }) {
   return (
     <nav
       aria-label="Navigation dev (hors production)"
-      className="fixed bottom-3 right-3 z-50 flex items-center gap-3 rounded-md border border-slate-700 bg-slate-900/90 px-3 py-1.5 text-xs font-medium shadow-lg backdrop-blur-sm print-preview:hidden print:hidden"
+      // Desktop (md+) : barre pleine largeur EN HAUT (menu à gauche ; le zoom du CV
+      // court vient se placer à droite, cf. CvZoomSlider). Mobile : pastille en bas à
+      // droite (pas de conflit avec la barre d'outils mobile fixe en haut).
+      className="fixed bottom-3 right-3 z-[100] flex items-center gap-3 rounded-md border border-slate-700 bg-slate-900/90 px-3 py-1.5 text-xs font-medium shadow-lg backdrop-blur-sm print-preview:hidden print:hidden md:inset-x-0 md:bottom-auto md:top-0 md:h-10 md:rounded-none md:border-x-0 md:border-t-0 md:px-4 md:shadow-md"
     >
       <span className="rounded bg-slate-800 px-1.5 py-0.5 font-mono text-[0.65rem] tracking-wide text-teal-300">
         {badge}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Réserve TOUJOURS la gouttière de scrollbar → quand le contenu déborde (ex. zoom du
+   CV court augmenté) et que la scrollbar apparaît/disparaît, la largeur utile ne bouge
+   pas : les éléments fixes (barre dev + zoom) ne se décalent plus. Neutre à l'impression. */
+@media screen {
+  html {
+    scrollbar-gutter: stable;
+  }
+}
+
 :root {
   /**
    * Espacement entre la barre de titre (border-b) et le contenu de la section.


### PR DESCRIPTION
## Problème (screenshot)

La barre de nav dev (`LOCAL · Renders · Components · LLM guide`) et le curseur de **Zoom**
étaient tous deux `fixed` en **bas à droite** → ils **se chevauchaient** (illisible). De plus,
quand le zoom augmentait et que la scrollbar apparaissait, ces éléments se **décalaient**.

## Changement

- **Desktop** : la nav dev devient une **barre pleine largeur en haut** (« header de menu »,
  menu à gauche). Le curseur de zoom se positionne **en haut à droite**, dans cette barre.
  Le contenu du CV démarre dessous (spacer `h-4`, écran uniquement).
- **Mobile** : nav dev en pastille **en bas à droite** (inchangé — évite le conflit avec la
  barre d'outils mobile fixe en haut). Zoom masqué (déjà `md:flex`).
- **Plus de décalage** : `scrollbar-gutter: stable` sur `html` (écran) → la gouttière de
  scrollbar est **toujours réservée** ⇒ son apparition/disparition ne déplace plus les
  éléments fixes.
- **Impression intacte** : barre dev + spacer en `print:hidden print-preview:hidden` → **aucun
  impact** sur l'aperçu `?print` ni le PDF.

## Vérification (Playwright, dev server)

| Cas | Résultat |
| --- | --- |
| `/short` desktop | barre pleine largeur (menu gauche · zoom droite), contenu dégagé (gap 8px), **0 chevauchement** |
| `/full` desktop | barre pleine largeur (menu gauche, pas de zoom), contenu dégagé |
| Zoom 100 % → 150 % | barre & zoom **ne bougent pas** (scrollbar-gutter stable) |
| Aperçu `?print=1` | barre + spacer masqués, `container top = 0` (**pas de fuite**), zoom masqué |
| PDF court | **1 page** (spacer/barre `print:hidden`, layout d'impression inchangé) |
| Mobile 375 | nav dev pastille en bas, zoom masqué, `container pt = 12px`, **0 débordement** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)