### PR TITLE
test(e2e): réparer 7 specs stale + gater le sous-ensemble robuste en CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,16 @@
-# E2E workflow — runs ONLY the print section-rhythm spec (regression net for my-resume#108).
+# E2E workflow — filet de régression « technico-fonctionnel », robuste à l'OS.
 #
-# Deliberately NOT the full Playwright suite: e2e/dev-components.spec.ts carries
-# darwin pixel snapshots that would fail on ubuntu runners.
+# On lance TOUTE la suite Playwright SAUF :
+#   - e2e/dev-components.spec.ts : snapshots pixel macOS → échoueraient sur ubuntu
+#     (exclu en ne le passant pas au runner) ;
+#   - les tests marqués `@local-only` : ils mesurent des pixels dépendant des
+#     métriques de glyphes (police système macOS ≠ ubuntu) → filtrés via
+#     `--grep-invert`. Ils restent joués en local. Les règles générales
+#     (comportement, navigation, largeurs/positions CSS, rythme inter-sections)
+#     sont, elles, gatées ici.
+#
+# Ajouter un nouveau spec le met AUTOMATIQUEMENT sous CI (glob `e2e/*.spec.ts`) —
+# c'est voulu : éviter qu'un test répare aujourd'hui re-casse sans filet demain.
 #
 # The Playwright webServer (playwright.config.ts) runs `next start` on :3457, which
 # needs a prior production build — so we `npm run build` before `playwright test`.
@@ -31,7 +40,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  print-rhythm:
+  e2e:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -52,5 +61,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Run print section-rhythm e2e
-        run: npx playwright test e2e/print-section-rhythm.spec.ts
+      # Toute la suite sauf dev-components (snapshots macOS) et les tests
+      # `@local-only` (sensibles aux polices système). Cf. l'en-tête du fichier.
+      - name: Run e2e (OS-agnostic subset)
+        run: npx playwright test --grep-invert "@local-only" $(ls e2e/*.spec.ts | grep -v 'dev-components.spec.ts')

--- a/e2e/cv-column-alignment.spec.ts
+++ b/e2e/cv-column-alignment.spec.ts
@@ -1,10 +1,15 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Grille 3 colonnes (domaines) + split 1/3 + 2/3 (#left / #main) :
- * le bord gauche de la 2ᵉ colonne domaine (Dev) doit coïncider avec #main.
+ * Alignement colonnes du CV COURT (`/short`, `CompactCvLayout`) : grille 3 colonnes
+ * (domaines) + split 1/3 + 2/3 (`#left` / `#main`). Le bord gauche de la 2ᵉ colonne
+ * domaine (Dev) doit coïncider avec `#main`, la 1ʳᵉ (Agile) avec `#left`.
+ *
+ * ⚠️ Le CV COMPLET (`/fr`, `OfferTailoredShell`) n'a plus de split `#main`/`#left` :
+ * il a été unifié en une seule colonne linéaire (`.cv-full-cv-print-root`). Il n'y a
+ * donc plus rien à aligner de ce côté — l'ancien cas « CV complet » a été retiré.
  */
-test.describe('CV desktop column alignment', () => {
+test.describe('CV court — alignement colonnes', () => {
   test.use({ viewport: { width: 1280, height: 900 } });
 
   async function expectDevAlignedWithMain(
@@ -50,12 +55,6 @@ test.describe('CV desktop column alignment', () => {
       `First domain left (${aX}px) should match #left left (${lX}px)`,
     ).toBeLessThanOrEqual(2);
   }
-
-  test('CV complet : Dev ↔ #main, Agile ↔ #left', async ({ page }) => {
-    await page.goto('/fr');
-    await expectDevAlignedWithMain(page);
-    await expectAgileAlignedWithLeft(page);
-  });
 
   test('CV court : Dev ↔ #main, Agile ↔ #left', async ({ page }) => {
     await page.goto('/fr/short');

--- a/e2e/cv-row-alignment.spec.ts
+++ b/e2e/cv-row-alignment.spec.ts
@@ -3,35 +3,42 @@ import { test, expect } from '@playwright/test';
 test.describe('CV title/date rows (mobile)', () => {
   test.use({ viewport: { width: 375, height: 800 } });
 
-  test('job mobile: ligne 1 client seul; ligne 2 poste et dates (alignement bas)', async ({
-    page,
-  }) => {
-    await page.goto('/fr');
-    const job = page.locator('#jobs li').first().locator('div[id]');
-    const row1 = job.locator('> .cv-row-with-side-meta').first();
-    const meta = job.getByTestId('job-meta-mobile');
-    await expect(row1).toBeVisible();
-    await expect(meta).toBeVisible();
+  // @local-only : compare des bords BAS de textes alignés sur la baseline
+  // (`items-baseline`) → dépend des métriques de glyphes, donc de la police
+  // système (macOS ≠ ubuntu). Exclu de la CI (cf. .github/workflows/e2e.yml).
+  test(
+    'job mobile: ligne 1 client seul; ligne 2 poste et dates (alignement bas)',
+    { tag: '@local-only' },
+    async ({ page }) => {
+      await page.goto('/fr');
+      const job = page.locator('#jobs li').first().locator('div[id]');
+      const row1 = job.locator('> .cv-row-with-side-meta').first();
+      const meta = job.getByTestId('job-meta-mobile');
+      await expect(row1).toBeVisible();
+      await expect(meta).toBeVisible();
 
-    const row1Date = row1.locator('span').nth(1);
-    await expect(row1Date).toBeHidden();
+      const row1Date = row1.locator('span').nth(1);
+      await expect(row1Date).toBeHidden();
 
-    const role = meta.locator('[data-job-meta="role"]');
-    const dates = meta.locator('[data-job-meta="dates"]');
-    await expect(role).toBeVisible();
-    await expect(dates).toBeVisible();
-    const lb = await role.evaluate((el) => el.getBoundingClientRect().bottom);
-    const rb = await dates.evaluate((el) => el.getBoundingClientRect().bottom);
-    expect(
-      Math.abs(lb - rb),
-      `Bottom edges should align (left=${lb}, right=${rb})`,
-    ).toBeLessThanOrEqual(2);
+      const role = meta.locator('[data-job-meta="role"]');
+      const dates = meta.locator('[data-job-meta="dates"]');
+      await expect(role).toBeVisible();
+      await expect(dates).toBeVisible();
+      const lb = await role.evaluate((el) => el.getBoundingClientRect().bottom);
+      const rb = await dates.evaluate(
+        (el) => el.getBoundingClientRect().bottom,
+      );
+      expect(
+        Math.abs(lb - rb),
+        `Bottom edges should align (left=${lb}, right=${rb})`,
+      ).toBeLessThanOrEqual(2);
 
-    const roleText = await role.textContent();
-    const datesText = await dates.textContent();
-    expect(roleText?.trim().length ?? 0).toBeGreaterThan(0);
-    expect(datesText?.trim().length ?? 0).toBeGreaterThan(0);
-  });
+      const roleText = await role.textContent();
+      const datesText = await dates.textContent();
+      expect(roleText?.trim().length ?? 0).toBeGreaterThan(0);
+      expect(datesText?.trim().length ?? 0).toBeGreaterThan(0);
+    },
+  );
 
   test('job mobile: bouton détail déplie texte long ou puces', async ({
     page,
@@ -82,21 +89,49 @@ test.describe('CV title/date rows (mobile)', () => {
     await expect(meta).toBeHidden();
   });
 
-  test('project row: title and dates share bottom edge', async ({ page }) => {
+  test('project row: title and year share the first row, detail below', async ({
+    page,
+  }) => {
     await page.goto('/fr');
-    // Mobile : deux blocs projets (sidebar masquée + bas de page) ; cibler le visible.
-    const row = page
-      .locator('section[data-cv-section="projects"]')
-      .last()
-      .locator('li')
-      .first()
-      .locator('section .cv-row-with-side-meta')
+    // CV complet unifié : une SEULE section projets, entrées en grille `.cv-entry`
+    // (`'title year' / 'detail detail'`, align-items: baseline). Sous md, le titre
+    // et l'année sont sur la 1ʳᵉ ligne (année collée à droite), le détail sur la 2ᵉ.
+    const entry = page
+      .locator('section[data-cv-section="projects"] li.cv-entry')
       .first();
-    await expect(row).toBeVisible();
-    const left = row.locator('span').first();
-    const right = row.locator('span').nth(1);
-    const lb = await left.evaluate((el) => el.getBoundingClientRect().bottom);
-    const rb = await right.evaluate((el) => el.getBoundingClientRect().bottom);
-    expect(Math.abs(lb - rb)).toBeLessThanOrEqual(2);
+    const title = entry.locator('.cv-entry-title');
+    const year = entry.locator('.cv-entry-year');
+    const detail = entry.locator('.cv-entry-detail');
+    await expect(title).toBeVisible();
+    await expect(year).toBeVisible();
+
+    const box = (loc: import('@playwright/test').Locator) =>
+      loc.evaluate((el) => {
+        const r = el.getBoundingClientRect();
+        return { top: r.top, bottom: r.bottom };
+      });
+
+    const t = await box(title);
+    const y = await box(year);
+
+    // Titre (16px) et année (14px) partagent la MÊME ligne (alignés sur la
+    // baseline) : leurs plages verticales se chevauchent nettement.
+    expect(
+      y.top,
+      `year top (${y.top}) should sit within the title row (${t.top}–${t.bottom})`,
+    ).toBeLessThan(t.bottom);
+    expect(
+      y.bottom,
+      'year bottom should sit within the title row',
+    ).toBeGreaterThan(t.top);
+
+    // Le détail est sur la ligne SUIVANTE (2ᵉ ligne de la grille), sous le titre.
+    if (await detail.count()) {
+      const d = await box(detail);
+      expect(
+        d.top,
+        `detail top (${d.top}) should be below the title row (bottom ${t.bottom})`,
+      ).toBeGreaterThanOrEqual(t.bottom - 1);
+    }
   });
 });

--- a/e2e/mobile-section-spacing.spec.ts
+++ b/e2e/mobile-section-spacing.spec.ts
@@ -1,49 +1,53 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Rythme vertical mobile : écart titre→profil proche de l’écart profil→domaines (marges de section homogènes).
+ * Rythme vertical mobile : les écarts entre sections EN FLUX (Profil → Domaines →
+ * Adéquation poste) sont du même ordre (marges de section homogènes).
+ *
+ * ⚠️ On ne compare PAS header → Profil : sous md, `.cv-full-cv-print-root` porte
+ * `mt-20` (80px) de CLEARANCE pour la barre d'outils fixe — un écart volontairement
+ * plus grand, pas du rythme de section. Le comparer au gap inter-section (~24px)
+ * donnait un faux positif (ratio ~3,2). On mesure donc deux gaps inter-section
+ * consécutifs, qui doivent rester homogènes.
  */
 test.describe('CV mobile vertical rhythm', () => {
   test.use({ viewport: { width: 375, height: 800 } });
 
-  test('header→about et about→domains : écarts du même ordre', async ({
+  test('about→domains et domains→adéquation : écarts du même ordre', async ({
     page,
   }) => {
     await page.goto('/fr');
 
-    const headerBlock = page.locator('header .header-content');
     const about = page.locator('#about');
     const domains = page.locator('#domains');
+    const jobFit = page.locator('#job-fit');
 
-    await expect(headerBlock).toBeVisible();
     await expect(about).toBeVisible();
     await expect(domains).toBeVisible();
+    await expect(jobFit).toBeVisible();
 
-    const headerBottom = await headerBlock.evaluate(
-      (el) => el.getBoundingClientRect().bottom,
-    );
-    const aboutTop = await about.evaluate(
-      (el) => el.getBoundingClientRect().top,
-    );
-    const aboutBottom = await about.evaluate(
-      (el) => el.getBoundingClientRect().bottom,
-    );
-    const domainsTop = await domains.evaluate(
-      (el) => el.getBoundingClientRect().top,
-    );
+    const bottom = (loc: import('@playwright/test').Locator) =>
+      loc.evaluate((el) => el.getBoundingClientRect().bottom);
+    const top = (loc: import('@playwright/test').Locator) =>
+      loc.evaluate((el) => el.getBoundingClientRect().top);
 
-    const gapHeaderAbout = aboutTop - headerBottom;
+    const aboutBottom = await bottom(about);
+    const domainsTop = await top(domains);
+    const domainsBottom = await bottom(domains);
+    const jobFitTop = await top(jobFit);
+
     const gapAboutDomains = domainsTop - aboutBottom;
+    const gapDomainsJobFit = jobFitTop - domainsBottom;
 
-    expect(gapHeaderAbout, 'header → about').toBeGreaterThanOrEqual(12);
     expect(gapAboutDomains, 'about → domains').toBeGreaterThanOrEqual(12);
+    expect(gapDomainsJobFit, 'domains → job-fit').toBeGreaterThanOrEqual(12);
 
     const ratio =
-      Math.max(gapHeaderAbout, gapAboutDomains) /
-      Math.min(gapHeaderAbout, gapAboutDomains);
+      Math.max(gapAboutDomains, gapDomainsJobFit) /
+      Math.min(gapAboutDomains, gapDomainsJobFit);
     expect(
       ratio,
-      `Gaps should be similar (${gapHeaderAbout}px vs ${gapAboutDomains}px)`,
+      `Gaps should be similar (${gapAboutDomains}px vs ${gapDomainsJobFit}px)`,
     ).toBeLessThanOrEqual(1.55);
   });
 });

--- a/e2e/offer-match-query.spec.ts
+++ b/e2e/offer-match-query.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test';
 
+/**
+ * Sur le CV complet, l'adéquation poste issue des paramètres d'offre est rendue par
+ * la section BODY `#job-fit` (`JobFitSection`, pastilles `match`) — il n'y a pas de
+ * bandeau de pastilles dans l'en-tête (l'ancien `data-testid="header-job-fit-pills"`
+ * n'a jamais été branché sur une page). On valide donc le rendu dans `#job-fit`.
+ */
 test.describe('Offer match (query params)', () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
@@ -9,9 +15,9 @@ test.describe('Offer match (query params)', () => {
     const q =
       'company=TestCo&title=Developer&requirement=Java:java,spring&requirement=SQL:sql';
     await page.goto(`/fr?${q}`);
-    const pills = page.getByTestId('header-job-fit-pills');
-    await expect(pills).toBeVisible();
-    await expect(pills.getByText('Java', { exact: true })).toBeVisible();
+    const jobFit = page.locator('#job-fit');
+    await expect(jobFit).toBeVisible();
+    await expect(jobFit.getByText('Java', { exact: true })).toBeVisible();
   });
 
   test('requirement avec @id catalogue matche une mission (Vue.js)', async ({
@@ -20,21 +26,28 @@ test.describe('Offer match (query params)', () => {
     const q =
       'company=Padoa&title=Dev&requirement=Vue.js%3A%40an8YW0VVTf2JuZZZo1W0pw';
     await page.goto(`/fr?${q}`);
-    const pills = page.getByTestId('header-job-fit-pills');
-    await expect(pills).toBeVisible();
-    await expect(pills.getByText('Vue.js', { exact: true })).toBeVisible();
+    const jobFit = page.locator('#job-fit');
+    await expect(jobFit).toBeVisible();
+    await expect(jobFit.getByText('Vue.js', { exact: true })).toBeVisible();
   });
 
   test('racine offre → version courte conserve les paramètres GET', async ({
     page,
   }) => {
+    // La bascule court/complet est DESKTOP-only (cf. HeaderToolbar : « ni bascule
+    // court/complet … Ces contrôles restent sur desktop »). En mobile, on ne
+    // switche pas de vue (le choix se fait à l'impression, nouvel onglet). On
+    // valide donc la conservation des params sur le vrai lien : `CvModeToggle`,
+    // même onglet, dans la barre desktop.
+    await page.setViewportSize({ width: 1280, height: 900 });
     const q =
       'company=TestCo&title=Developer&requirement=Java:java,spring&requirement=SQL:sql';
     await page.goto(`/fr?${q}`);
-    await expect(page.getByTestId('header-job-fit-pills')).toBeVisible();
-    /** Barre mobile : menu ouvert ; cibler le 2ᵉ lien (le 1ᵉʳ est dans la barre `md:` masquée). */
-    await page.getByTestId('cv-mobile-menu-toggle').click();
-    await page.locator('a[title="Version courte"]').last().click();
+    await expect(page.locator('#job-fit')).toBeVisible();
+    await page
+      .locator('[data-testid="cv-header-toolbar"] a[href*="/short"]')
+      .first()
+      .click();
     await expect(page).toHaveURL(/\/fr\/short\?/);
     const u = new URL(page.url());
     expect(u.searchParams.get('company')).toBe('TestCo');

--- a/e2e/pill-links.spec.ts
+++ b/e2e/pill-links.spec.ts
@@ -37,10 +37,12 @@ test.describe('Pill links', () => {
         if (href) anchorIds.add(href.slice(1)); // strip leading #
       }
 
-      // Every referenced id must exist as an element on the page
+      // Every referenced id must exist as an element on the page.
+      // NB : sélecteur par attribut `[id="…"]` (et non `#${CSS.escape(id)}`) —
+      // `CSS` est un global navigateur, indéfini dans le contexte Node de Playwright.
       for (const id of anchorIds) {
         await expect(
-          page.locator(`#${CSS.escape(id)}`),
+          page.locator(`[id="${id}"]`),
           `Anchor target #${id} should exist`,
         ).toHaveCount(1);
       }

--- a/e2e/print-layout.spec.ts
+++ b/e2e/print-layout.spec.ts
@@ -1,29 +1,15 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * En @media print, la grille est en 3 colonnes : sans print:col-span-2 sur #main,
- * les missions ne font qu’1/3 de la largeur. On valide via emulateMedia('print').
+ * En @media print, la grille du CV COURT est en 3 colonnes : sans print:col-span-2
+ * sur #main, les missions ne font qu’1/3 de la largeur. On valide via emulateMedia('print').
+ *
+ * ⚠️ Le CV COMPLET (`/fr`) n'a plus de split `#main`/`#left` : unifié en une seule
+ * colonne linéaire (`.cv-full-cv-print-root`). L'ancien cas « CV complet » a été retiré
+ * (cf. e2e/cv-column-alignment.spec.ts, même bascule).
  */
 test.describe('Print layout', () => {
   test.use({ viewport: { width: 1200, height: 900 } });
-
-  test('CV complet : #main nettement plus large que #left (print)', async ({
-    page,
-  }) => {
-    await page.goto('/fr');
-    await page.emulateMedia({ media: 'print' });
-    const { mainW, leftW } = await page.evaluate(() => {
-      const main = document.querySelector('#main');
-      const left = document.querySelector('#left');
-      return {
-        mainW: main?.getBoundingClientRect().width ?? 0,
-        leftW: left?.getBoundingClientRect().width ?? 0,
-      };
-    });
-    expect(leftW, 'colonne gauche').toBeGreaterThan(64);
-    expect(mainW, 'colonne missions').toBeGreaterThan(leftW * 1.45);
-    await page.emulateMedia({ media: 'screen' });
-  });
 
   test('CV court : #main nettement plus large que #left (print)', async ({
     page,

--- a/e2e/short-cv-section-spacing.spec.ts
+++ b/e2e/short-cv-section-spacing.spec.ts
@@ -51,25 +51,37 @@ test.describe('CV court — rythme vertical régulier', () => {
     ).toBeLessThanOrEqual(1.2);
   });
 
-  test('En-tête : nom→rôle == rôle→âge (rythme uniforme)', async ({ page }) => {
-    // Desktop : c'est là que les marges divergeaient (rôle md:mt-3 vs âge md:mt-2).
-    await page.setViewportSize({ width: 1024, height: 1400 });
-    await page.goto(`/fr/short?${OFFER_QS}`);
+  // @local-only : écarts entre lignes de texte (nom/rôle/âge) grignotés par le
+  // débord de glyphe → dépend de la police système (macOS ≠ ubuntu). Le ratio
+  // (rythme uniforme) reste vrai partout, mais les valeurs absolues divergent.
+  // Exclu de la CI (cf. .github/workflows/e2e.yml).
+  test(
+    'En-tête : nom→rôle == rôle→âge (rythme uniforme)',
+    { tag: '@local-only' },
+    async ({ page }) => {
+      // Desktop : c'est là que les marges divergeaient (rôle md:mt-3 vs âge md:mt-2).
+      await page.setViewportSize({ width: 1024, height: 1400 });
+      await page.goto(`/fr/short?${OFFER_QS}`);
 
-    const name = await bbox(page, '[data-cv-id="fullname"]');
-    const role = await bbox(page, '[data-cv-id="title"]');
-    const age = await bbox(page, '[data-cv-id="age"]');
+      const name = await bbox(page, '[data-cv-id="fullname"]');
+      const role = await bbox(page, '[data-cv-id="title"]');
+      const age = await bbox(page, '[data-cv-id="age"]');
 
-    const nameToRole = role.top - name.bottom;
-    const roleToAge = age.top - role.bottom;
+      const nameToRole = role.top - name.bottom;
+      const roleToAge = age.top - role.bottom;
 
-    expect(nameToRole, 'nom → rôle').toBeGreaterThanOrEqual(3);
-    expect(roleToAge, 'rôle → âge').toBeGreaterThanOrEqual(3);
-    expect(
-      ratio(nameToRole, roleToAge),
-      `gaps en-tête homogènes (${Math.round(nameToRole)}px vs ${Math.round(
-        roleToAge,
-      )}px)`,
-    ).toBeLessThanOrEqual(1.25);
-  });
+      // En desktop, `/short` rend en typo A4 compacte (`.cv-print-preview` permanent
+      // + règles `min-width: 768px`) : les marges inter-lignes retombent à 2px → gaps
+      // ~1,6px. Le plancher garde juste des écarts POSITIFS et réels ; le vrai garde-fou
+      // est le ratio ci-dessous (rythme uniforme nom→rôle == rôle→âge).
+      expect(nameToRole, 'nom → rôle').toBeGreaterThanOrEqual(1);
+      expect(roleToAge, 'rôle → âge').toBeGreaterThanOrEqual(1);
+      expect(
+        ratio(nameToRole, roleToAge),
+        `gaps en-tête homogènes (${Math.round(nameToRole)}px vs ${Math.round(
+          roleToAge,
+        )}px)`,
+      ).toBeLessThanOrEqual(1.25);
+    },
+  );
 });


### PR DESCRIPTION
## Contexte

4 specs Playwright échouaient sur `main` sans être gatées (la CI ne lançait qu'un seul test). En lançant la suite complète, **3 autres** échouaient aussi (introduits par #121–#126, après la vérif du 02/07). Toutes ces assertions « mentaient » sur le rendu CV actuel après les refontes de layout — je les ai recalées sur le comportement voulu, **sans affaiblissement gratuit**.

## Specs réparés

**Demandés (4) :**
- **mobile-section-spacing** — comparait en-tête→Profil (80px = dégagement volontaire de la barre fixe) à Profil→Domaines → compare maintenant 2 vrais écarts inter-sections (rythme CSS homogène).
- **cv-column-alignment** — cas « CV complet » cherchait `#main`/`#left`, supprimés à l'unification en colonne linéaire → cas retiré, « CV court » gardé.
- **cv-row-alignment** (ligne projet) — cherchait l'ancien `.cv-row-with-side-meta` + supposait 2 blocs → réécrit sur la grille `.cv-entry` (titre+année ligne 1, détail dessous).
- **short-cv-section-spacing** (en-tête) — plancher ≥ 3px trop haut (typo A4 compacte = 1,6px, rythme parfait) → plancher ≥ 1, le ratio ≤ 1,25 reste le vrai garde-fou.

**Découverts (3) :**
- **print-layout** — même `#main`/`#left` stale sur le CV complet → cas retiré, court gardé.
- **pill-links** — bug du test : `CSS.escape()` appelé côté Node → sélecteur `[id="…"]`. L'appli était OK.
- **offer-match-query** (3 tests) — ciblaient `header-job-fit-pills`, composant **jamais branché** ; l'adéquation vit dans `#job-fit` → reciblés. Le 3ᵉ testait une bascule complet→court **mobile qui n'existe plus** (volontairement desktop-only) → réécrit en desktop.

## CI

Le workflow lance désormais **toute la suite SAUF** :
- `dev-components.spec.ts` (snapshots pixel macOS, impossibles sur ubuntu) ;
- les tests marqués `{ tag: '@local-only' }` (mesures pixel dépendant de la police système ubuntu ≠ macOS — l'appli déclare `Raleway` mais ne la charge jamais → fallback système), via `--grep-invert`.

Glob `e2e/*.spec.ts` → **tout nouveau spec est auto-gaté** (le filet qui manquait pour éviter que ça re-casse en silence).

## Vérifs
- `npm run build` OK.
- Commande CI exacte rejouée en local → **30 passés** (`@local-only` filtrés, `dev-components` exclu).
- Suite complète locale → **32 passés**.
- `prettier:check` + `next lint` OK.

## Suivi (hors PR)
Composant mort `components/ShortHeaderJobFitPills.tsx` (jamais importé) à supprimer — nettoyage séparé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
