### PR TITLE
feat(cv): mobile — le CV court rebascule vers le complet (affichage unifié)

### DIFF
--- a/app/[lang]/short/page.tsx
+++ b/app/[lang]/short/page.tsx
@@ -14,6 +14,7 @@ import ShortPageWrapper from '@/components/ShortPageWrapper';
 import FullCvPrintPreviewEffect from '@/components/FullCvPrintPreviewEffect';
 import AtsLabelsEffect from '@/components/AtsLabelsEffect';
 import CvAutoprint from '@/components/CvAutoprint';
+import MobileShortToFullRedirect from '@/components/MobileShortToFullRedirect';
 import {
   resolveAboutText,
   resolveDomainDescription,
@@ -178,6 +179,9 @@ export default async function ShortPage({
   return (
     <>
       <Suspense fallback={null}>
+        {/* Mobile : le court ne s'affiche jamais → rebascule vers le complet
+            (sauf impression `?autoprint`/`?print`). Cf. backlog job-app 0016. */}
+        <MobileShortToFullRedirect lang={lang} />
         <FullCvPrintPreviewEffect />
         <AtsLabelsEffect />
       </Suspense>

--- a/components/MobileShortToFullRedirect.tsx
+++ b/components/MobileShortToFullRedirect.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useLayoutEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { fullHrefFromShortPath } from '@/lib/cv-mode-nav';
+import { isCvPrintPreviewQuery } from '@/lib/cv-print-preview';
+
+/**
+ * Sur MOBILE, le CV court ne doit jamais s'AFFICHER : le rendu mobile est unifié
+ * (toujours le complet). Le choix court/complet ne se fait qu'à l'IMPRESSION
+ * (cf. `MobilePrintChooser`), pas à l'affichage. Cette garde, montée sur
+ * `/[lang]/short`, rebascule vers `/[lang]` quand le viewport est mobile.
+ *
+ * ⚠️ EXEMPTION IMPRESSION — indispensable : le sélecteur d'impression mobile ouvre
+ * le PDF court via `/[lang]/short?autoprint=1` (et l'aperçu via `?print=1`) dans un
+ * nouvel onglet, souvent mobile. Rediriger ces contextes casserait l'impression du
+ * court depuis mobile. On NE redirige donc jamais si `?autoprint=1` ou `?print`.
+ *
+ * Le seuil `max-width: 767px` = le breakpoint `md` de Tailwind (mobile = < md),
+ * cohérent avec le masquage de la bascule court/complet dans la barre mobile.
+ * `router.replace` (pas `push`) → pas d'entrée d'historique, query préservée.
+ */
+
+// Layout-effect isomorphe : minimise le flash (redirige avant le paint côté
+// client) sans warning SSR.
+const useIsoLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+const MOBILE_MEDIA_QUERY = '(max-width: 767px)';
+
+export default function MobileShortToFullRedirect({ lang }: { lang: string }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useIsoLayoutEffect(() => {
+    const sp = new URLSearchParams(searchParams.toString());
+
+    // Exemption impression : ne jamais voler l'onglet d'impression du court.
+    if (sp.get('autoprint') === '1') return;
+    if (isCvPrintPreviewQuery(sp)) return;
+
+    if (!window.matchMedia(MOBILE_MEDIA_QUERY).matches) return;
+
+    router.replace(fullHrefFromShortPath(lang, sp));
+  }, [searchParams, router, lang]);
+
+  return null;
+}

--- a/e2e/mobile-short-to-full.spec.ts
+++ b/e2e/mobile-short-to-full.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Backlog job-app 0016 — sur MOBILE, le CV court ne s'AFFICHE jamais : la route
+ * `/[lang]/short` rebascule vers `/[lang]` (affichage mobile unifié = complet).
+ * L'IMPRESSION reste indépendante (sélecteur `MobilePrintChooser`) : les contextes
+ * `?autoprint=1` et `?print` sont EXEMPTÉS du redirect, sinon on casserait
+ * l'impression du court depuis mobile.
+ *
+ * On teste 4 invariants : redirect mobile (+ query préservée), pas de redirect
+ * desktop, exemption `?print`, et exemption `?autoprint` (l'impression part bien
+ * depuis /short, pas depuis le complet).
+ */
+
+const MOBILE = { width: 390, height: 840 };
+const DESKTOP = { width: 1200, height: 900 };
+
+test.describe('Mobile : /short → /complet', () => {
+  test.use({ viewport: MOBILE });
+
+  test('mobile : /fr/short rebascule vers /fr', async ({ page }) => {
+    await page.goto('/fr/short');
+    await expect(page).toHaveURL(/\/fr(\?.*)?$/);
+  });
+
+  test('mobile : la query est préservée à la bascule', async ({ page }) => {
+    await page.goto('/fr/short?company=Acme&title_fr=Lead');
+    await expect(page).toHaveURL(/\/fr\?.*company=Acme/);
+    await expect(page).toHaveURL(/title_fr=Lead/);
+    await expect(page).not.toHaveURL(/\/short/);
+  });
+
+  test('mobile : ?print=1 est EXEMPTÉ (reste sur /short, aperçu impression)', async ({
+    page,
+  }) => {
+    await page.goto('/fr/short?print=1');
+    // Laisse le temps à un éventuel redirect de se produire, puis vérifie qu'il
+    // n'a PAS eu lieu.
+    await page.waitForTimeout(800);
+    await expect(page).toHaveURL(/\/fr\/short/);
+  });
+
+  test('mobile : ?autoprint=1 imprime bien le COURT (pas le complet)', async ({
+    page,
+  }) => {
+    // Stub d'impression : enregistre la route active au moment du print.
+    await page.addInitScript(() => {
+      (window as unknown as { __printedAt: string | null }).__printedAt = null;
+      window.print = () => {
+        (window as unknown as { __printedAt: string | null }).__printedAt =
+          location.pathname;
+      };
+    });
+    await page.goto('/fr/short?autoprint=1');
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __printedAt: string | null }).__printedAt !==
+        null,
+    );
+    const printedAt = await page.evaluate(
+      () => (window as unknown as { __printedAt: string | null }).__printedAt,
+    );
+    expect(printedAt).toMatch(/\/fr\/short$/);
+  });
+});
+
+test.describe('Desktop : /short reste /short', () => {
+  test.use({ viewport: DESKTOP });
+
+  test('desktop : /fr/short ne rebascule pas', async ({ page }) => {
+    await page.goto('/fr/short');
+    await page.waitForTimeout(800);
+    await expect(page).toHaveURL(/\/fr\/short/);
+  });
+});

--- a/e2e/short-cv-section-spacing.spec.ts
+++ b/e2e/short-cv-section-spacing.spec.ts
@@ -3,7 +3,16 @@ import { test, expect, type Page } from '@playwright/test';
 /**
  * CV court (`/fr/short`) — rythme vertical RÉGULIER, piloté par des tokens uniques.
  *
- * Deux règles générales (mêmes valeurs web / impression / mobile) :
+ * NB (backlog 0016) : sur un viewport mobile, `/short` rebascule vers le complet
+ * (le court ne s'affiche jamais en mobile ; le choix court/complet se fait à
+ * l'impression). On mesure donc via `?print=1`, EXEMPTÉ de cette bascule : le court
+ * reste rendu dans son régime d'IMPRESSION (que Chrome évalue < 768px) — c'est le
+ * rythme A4 canonique, le seul qui compte désormais pour le court. Ce régime est
+ * plus DENSE que l'ancien reflow mobile (écarts ~5px au lieu de ~6+) : le vrai
+ * garde-fou reste le RATIO (rythme uniforme), le plancher n'assure que des écarts
+ * positifs et réels (token `--cv-section-body-gap`, stable inter-OS).
+ *
+ * Deux règles générales (rythme identique web / impression) :
  *  1. Profil : filet→intro == intro→domaines. Les domaines sont une SOUS-PARTIE
  *     du Profil → espacés comme du body (`--cv-section-body-gap`), pas comme une
  *     section (le `#domains` annule le flex-gap inter-section, le seul écart
@@ -32,7 +41,9 @@ test.describe('CV court — rythme vertical régulier', () => {
     page,
   }) => {
     await page.setViewportSize({ width: 390, height: 1600 });
-    await page.goto(`/fr/short?${OFFER_QS}`);
+    // `print=1` : exempte le redirect mobile→complet (0016) → le court reste
+    // rendu (identique à la vue normale, `.cv-print-preview` permanent).
+    await page.goto(`/fr/short?print=1&${OFFER_QS}`);
 
     const filet = await bbox(page, '#cv-short-about h2');
     const intro = await bbox(page, '#cv-short-about p');
@@ -41,8 +52,10 @@ test.describe('CV court — rythme vertical régulier', () => {
     const filetToIntro = intro.top - filet.bottom;
     const introToDomains = firstDomain.top - intro.bottom;
 
-    expect(filetToIntro, 'filet Profil → intro').toBeGreaterThanOrEqual(6);
-    expect(introToDomains, 'intro → 1er domaine').toBeGreaterThanOrEqual(6);
+    // Régime impression du court (via `?print=1`) : écarts denses (~5px mesurés).
+    // Plancher = juste « positif et réel » ; le vrai garde-fou est le ratio ci-dessous.
+    expect(filetToIntro, 'filet Profil → intro').toBeGreaterThanOrEqual(4);
+    expect(introToDomains, 'intro → 1er domaine').toBeGreaterThanOrEqual(4);
     expect(
       ratio(filetToIntro, introToDomains),
       `body-gap homogène (${Math.round(filetToIntro)}px vs ${Math.round(


### PR DESCRIPTION
Implémente le backlog **job-app 0016**.

## Problème (vérifié en live sur staging, 390px)
Sur mobile, `/[lang]/short` **affiche** un CV court réduit — **8 postes** (vs 16), sans les sections **Learnings / Hobbies** — différent du complet. Attendu : sur mobile le rendu est **unifié** (toujours le complet) ; le court/complet ne se choisit qu'à **l'impression**.

## Solution
- Nouveau composant client **`MobileShortToFullRedirect`** monté sur la route courte : si `matchMedia('(max-width: 767px)')`, `router.replace` vers `/[lang]` (query préservée, pas d'entrée d'historique). Layout-effect isomorphe → flash minimisé.
- **⚠️ Exemption impression (le point dur)** : jamais de redirect si `?autoprint=1` ou `?print`. Sinon on casserait l'impression du court depuis mobile — le `MobilePrintChooser` ouvre justement `/short?autoprint=1` dans un nouvel onglet (souvent mobile).

## Tests
- `e2e/mobile-short-to-full.spec.ts` : (1) mobile `/fr/short` → `/fr` ; (2) query préservée ; (3) mobile `?print=1` reste sur `/short` ; (4) mobile `?autoprint=1` imprime bien depuis `/short` (pas le complet) ; (5) desktop `/fr/short` ne bouge pas.
- CI e2e : spec ajouté à la commande (specs listés explicitement pour éviter les snapshots darwin de `dev-components.spec.ts`).

## À valider sur la preview
- Ouvrir la preview en 390px : `/en/short` doit rebasculer sur `/en` (avec Learnings/Hobbies + 16 postes).
- `/en/short?print=1` (aperçu) et l'impression mobile du court (bouton imprimer → « CV court ») doivent rester intacts.
- Desktop : `/en/short` inchangé.

Backlog : ferme job-app 0016 (le suivi reste côté job-app/features).