### PR TITLE
docs(features): recadre la fiche 0004 (data layer déjà splittée, reste le texte en dur)

### DIFF
--- a/features/0004-data-layer-decouplee.md
+++ b/features/0004-data-layer-decouplee.md
@@ -1,6 +1,6 @@
 ---
 id: 0004
-title: Data layer découplée (bundle.json → cv.json / tech-catalog / locales)
+title: Retirer les derniers textes en dur des composants (fallbacks FR/EN)
 type: refactor
 priority: P3
 version:
@@ -9,33 +9,43 @@ pr:
 created: 2026-07-02
 ---
 
-# 0004 — Data layer découplée
+# 0004 — Retirer les derniers textes en dur des composants (fallbacks FR/EN)
 
 ## Contexte / Problème
 
-Le `bundle.json` monolithique mélange données structurelles et textes localisés → i18n peu
-propre, duplication entre locales.
+**Mise à jour 2026-07-05** : le découpage du data layer proposé par cette fiche est
+**déjà fait**, mais pas exactement comme décrit à l'origine — vérifié à la relecture du
+backlog (repo `data/cv/`) :
+
+- `bundle.json` **a disparu** (aucune trace sur `main`), remplacé par **4 fichiers** :
+  `profile.json`, `experience.json`, `tech-catalog.json`, `locales/{fr,en}.json`
+  (`lib/cv-data.ts:loadCvSources`). Découpage plus fin que les 3 fichiers proposés
+  (`cv.json` a été scindé en `profile.json` + `experience.json`), mais l'esprit
+  (structure / catalogue tech / textes localisés séparés) est respecté.
+- Les 4 dernières mentions de « bundle.json » dans le code (`dev/components/page.tsx`,
+  `CompactCvLayout.tsx`, `scripts/split-bundle.ts`, `lib/match-catalog-schema.ts`) sont des
+  **commentaires morts** (dont le script de migration one-shot lui-même), pas des
+  dépendances runtime — à nettoyer un jour, non bloquant.
+
+**Ce qui reste réellement à faire** (le seul critère non rempli) : **5 occurrences** du
+motif `lang === 'fr' ? '<texte>' : '<texte>'` (texte en dur, pas piloté par les locales)
+dans `components/CompactCvLayout.tsx` et `components/OfferTailoredShell.tsx` — labels de
+secours pour les titres de section (« Coordonnées »/« Contact », « Profil »/« Profile »).
 
 ## Proposition
 
-Séparer en 3 fichiers :
-
-| Fichier                        | Contenu                                                                    |
-| ------------------------------ | -------------------------------------------------------------------------- |
-| `data/cv/cv.json`              | Données neutres (dates, slugs, refs tech, structure jobs/studies/projects) |
-| `data/cv/tech-catalog.json`    | Dictionnaire techno (nom canonique + lien)                                 |
-| `data/cv/locales/{fr,en}.json` | Textes localisés + libellés UI                                             |
-
-Avantages : i18n propre (aucun texte en dur), données structurelles non dupliquées entre
-locales, tech-catalog source unique (matching offres + affichage), export DatoCMS possible
-via `scripts/export-datocms.ts`.
+Déplacer ces 5 libellés de secours vers `data/cv/locales/{fr,en}.json` (le mécanisme
+existe déjà partiellement, cf. `data.titles.contact` dans `CompactCvLayout.tsx`) pour
+qu'aucun composant ne contienne de texte FR/EN en dur, même en fallback.
 
 ## Critères d'acceptation
 
-- [ ] `bundle.json` scindé en 3 fichiers, chargeur adapté.
-- [ ] Aucun texte en dur dans les composants.
-- [ ] Parité de rendu FR/EN (4 rendus) conservée.
+- [x] `bundle.json` scindé, chargeur adapté (fait — 4 fichiers, cf. ci-dessus).
+- [ ] Aucun texte en dur dans les composants (5 occurrences restantes à traiter).
+- [ ] Parité de rendu FR/EN (4 rendus) conservée après le déplacement des libellés.
 
 ## Notes / décisions
 
-Migré depuis `ROADMAP.md`. NB : `tech-catalog.json` existe déjà partiellement (cf. #107).
+Migré depuis `ROADMAP.md`. Recadrée le 2026-07-05 après vérification de l'état réel du
+repo (le split de fichiers était déjà fait, la fiche décrivait un problème obsolète) —
+même id, périmètre resserré sur ce qui reste vraiment à faire.

--- a/features/README.md
+++ b/features/README.md
@@ -7,7 +7,7 @@ Règles : 1 PR par feature, squash-merge quand la CI est verte. Priorités P0 (u
 Statuts : 🔴 todo · 🟠 in-progress · ⛔ blocked · ✅ shipped. Rendu CV : respecter les
 invariants de `CLAUDE.md` et la checklist `docs/cv-rendering-review-checklist.md`.
 
-Dernière mise à jour : 2026-07-03
+Dernière mise à jour : 2026-07-05
 
 ## Actives (triées par priorité)
 
@@ -16,7 +16,7 @@ Dernière mise à jour : 2026-07-03
 | 0002 | Loisirs — bascule inline / 2 lignes via `?entriesLayout`             | feature  | P2   | 🔴 todo |     |
 | 0003 | Design system — CSS variables et tokens                              | refactor | P2   | 🔴 todo |     |
 | 0006 | Migration Next.js 14 → 15+/16                                        | chore    | P2   | 🔴 todo |     |
-| 0004 | Data layer découplée (bundle → cv/tech-catalog/locales)              | refactor | P3   | 🔴 todo |     |
+| 0004 | Retirer les derniers textes en dur des composants (fallbacks FR/EN)  | refactor | P3   | 🔴 todo |     |
 | 0005 | Primitives React réutilisables                                       | refactor | P3   | 🔴 todo |     |
 | 0007 | Retirer `?print` / `FullCvPrintPreviewEffect` résiduels              | refactor | P3   | 🔴 todo |     |
 | 0016 | /dev/renders — scroll bloqué dans certaines cellules de comparaison  | bug      | P3   | 🔴 todo |     |


### PR DESCRIPTION
## Contexte

En vérifiant le backlog, la fiche **0004** décrivait un problème déjà résolu : le
découpage `bundle.json` → fichiers séparés est **déjà fait**.

## Vérifié sur `main`

- `bundle.json` n'existe plus. `lib/cv-data.ts:loadCvSources` charge 4 fichiers :
  `profile.json`, `experience.json`, `tech-catalog.json`, `locales/{fr,en}.json`.
- Les 4 dernières mentions de « bundle.json » dans le code (`dev/components/page.tsx`,
  `CompactCvLayout.tsx`, `scripts/split-bundle.ts`, `lib/match-catalog-schema.ts`) sont
  des **commentaires morts** (dont le script de migration one-shot lui-même) — aucune
  dépendance runtime.
- **Seul le critère « aucun texte en dur » reste ouvert** : 5 occurrences du motif
  `lang === 'fr' ? '...' : '...'` dans `CompactCvLayout.tsx` et `OfferTailoredShell.tsx`
  (labels de secours Coordonnées/Contact, Profil/Profile).

## Changement

Recadre la fiche 0004 (même id) sur ce périmètre restant réel, plutôt que de la laisser
décrire un problème obsolète. Pas shippée — le critère manquant reste à traiter.

Docs-only, pas de changement de code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)