### PR TITLE
fix(dev): supprime le warning d'hydratation React sur /dev/renders

### DIFF
--- a/app/[lang]/dev/renders/page.tsx
+++ b/app/[lang]/dev/renders/page.tsx
@@ -331,7 +331,13 @@ export default function DevRendersPage() {
   const [genState, setGenState] = useState<GenerateState>('idle');
   const [genOutput, setGenOutput] = useState('');
   const [showLog, setShowLog] = useState(false);
-  const [bust, setBust] = useState(Date.now());
+  // Cache-buster des URLs /api/renders/file. Init stable (0) pour que le HTML
+  // SSR et le premier rendu client soient identiques (sinon warning
+  // d'hydratation « Prop src did not match ») ; résolu au montage.
+  const [bust, setBust] = useState(0);
+  useEffect(() => {
+    setBust(Date.now());
+  }, []);
   const [lastGenerated, setLastGenerated] = useState<number | null>(null);
   const [activeTab, setActiveTab] = useState<ActiveTab>('snapshots');
   const [expandedVariant, setExpandedVariant] = useState<string | null>(


### PR DESCRIPTION
## Quoi

Dans [`app/[lang]/dev/renders/page.tsx`](https://github.com/elzinko/my-resume/blob/claude/inspiring-bohr-cfed1c/app/%5Blang%5D/dev/renders/page.tsx), l'état `bust` (cache-buster des URLs `/api/renders/file?name=...&t=...`) était initialisé à `Date.now()` : le timestamp rendu côté SSR différait de celui du premier rendu client → warning d'hydratation React « Prop src did not match ».

Fix : init stable à `0` puis résolution en `Date.now()` dans un `useEffect` au montage — même pattern que les états `isLocal` et `isMobile` déjà présents dans le fichier.

## Pourquoi

Un mismatch d'hydratation pollue la console en dev et peut masquer de vrais problèmes ; sur cette page il se produisait à chaque chargement.

## Vérification

- `next dev` + navigation sur `/fr/dev/renders` : console propre, aucun warning/erreur d'hydratation ; les 8 images/PDF chargent avec le timestamp résolu côté client (`&t=1783276717319`).
- Comportement conservé : le buster est rafraîchi au montage et à chaque « Regenerate » (`setBust(Date.now())`).
- `npm test` (prettier:check + lint) ✅

Page dev-only, aucun impact sur le rendu du CV (web/print/court/complet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)