### PR TITLE
feat(dev): nav dev responsive — toujours en haut, pastille repliable en mobile

### DIFF
--- a/app/[lang]/dev/components/page.tsx
+++ b/app/[lang]/dev/components/page.tsx
@@ -341,7 +341,8 @@ export default async function DevComponentsPage({
   ];
 
   return (
-    <main className="text-cv-body mx-auto max-w-5xl px-6 py-10">
+    // max-md:pt-16 : dégage la pastille de nav dev flottante (mobile).
+    <main className="text-cv-body mx-auto max-w-5xl px-6 py-10 max-md:pt-16">
       <header className="mb-10">
         <h1 className="text-3xl font-semibold">Dev · Components storybook</h1>
         <p className="mt-2 text-sm text-cv-body-muted">

--- a/app/[lang]/dev/llm-guide/page.tsx
+++ b/app/[lang]/dev/llm-guide/page.tsx
@@ -21,7 +21,8 @@ export default function DevLlmGuidePage() {
   const markdown = buildLlmGuideMarkdown();
 
   return (
-    <div className="mx-auto max-w-4xl">
+    // max-md:pt-12 : dégage la pastille de nav dev flottante (mobile).
+    <div className="mx-auto max-w-4xl max-md:pt-12">
       <h1 className="mb-2 text-3xl font-semibold">Dev · LLM guide</h1>
       <p className="mb-6 text-sm text-slate-500">
         Rendu lisible de{' '}

--- a/app/[lang]/dev/renders/page.tsx
+++ b/app/[lang]/dev/renders/page.tsx
@@ -413,7 +413,9 @@ export default function DevRendersPage() {
         background: '#1a1a2e',
         color: '#e0e0e0',
         minHeight: '100vh',
-        padding: isMobile ? '1rem' : '2rem',
+        // Mobile : la pastille de nav dev flotte en haut à gauche → on dégage
+        // la zone du titre (56px ≈ safe-area + hauteur de la pastille).
+        padding: isMobile ? '3.5rem 1rem 1rem' : '2rem',
         overflowX: 'hidden',
       }}
     >

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -21,8 +21,9 @@ export default async function RootLayout({
       enableAnalitycs = false;
     }
   }
-  // Hors production : barre de nav dev EN HAUT (pleine largeur, desktop) → on réserve
-  // la hauteur en haut du contenu pour ne pas la recouvrir (mobile : barre en bas).
+  // Hors production : barre de nav dev EN HAUT sur tous les viewports (desktop :
+  // pleine largeur → on réserve la hauteur ; mobile : pastille repliée alignée sur
+  // la barre d'outils CV, aucune réserve nécessaire).
   const isDev = process.env.VERCEL_ENV !== 'production';
   return (
     <>
@@ -33,7 +34,8 @@ export default async function RootLayout({
       ) : null}
       {/* Réserve la hauteur de la barre dev (desktop) → le contenu démarre dessous.
           Écran uniquement : masqué en impression ET en aperçu `?print` (barre cachée
-          là), donc AUCUN impact sur le PDF / l'aperçu. Mobile : barre dev en bas. */}
+          là), donc AUCUN impact sur le PDF / l'aperçu. Mobile : pastille dev en haut
+          à gauche, dans la rangée de la barre d'outils CV (pas de réserve). */}
       {isDev ? (
         <div
           aria-hidden

--- a/components/DevNav.tsx
+++ b/components/DevNav.tsx
@@ -7,7 +7,17 @@ import React, { useEffect, useState } from 'react';
  *
  * Rendue par le layout CV UNIQUEMENT hors production (`VERCEL_ENV !== 'production'`,
  * décidé côté serveur → absente du DOM en prod). Jamais imprimée (`print:hidden`,
- * `print-preview:hidden`).
+ * `print-preview:hidden`), ni dans les iframes (vignettes de `/dev/renders`,
+ * stories de `/dev/components`) : elle se démonte quand `window.self !== window.top`.
+ *
+ * UN SEUL composant, toujours EN HAUT, deux rendus selon le viewport :
+ * - `md+` : barre pleine largeur en haut (badge + liens toujours visibles ; le
+ *   zoom du CV court vient se placer à droite, cf. `CvZoomSlider`).
+ * - `< md` : pastille en haut à gauche, alignée sur la rangée de la barre
+ *   d'outils CV mobile (zone libre à gauche du burger). Le badge d'environnement
+ *   sert de bouton : replié = badge seul, déplié = badge + les mêmes liens.
+ *   Quand le menu CV mobile est OUVERT (sélecteur de langue à gauche), la barre
+ *   s'efface via `:has()` pour ne pas le recouvrir.
  *
  * Le badge d'environnement dépend du hostname (client-only) : LOCAL (pas de
  * déploiement) / STAGING (staging.elzinko.fr) / PREVIEW (*.vercel.app).
@@ -29,6 +39,8 @@ export default function DevNav({ lang }: { lang: string }) {
   // Comparer) et les stories iframe de /dev/components embarquent les pages CV —
   // la barre dev n'y a rien à faire. Détection client-only (SSR : visible).
   const [inIframe, setInIframe] = useState(false);
+  // < md : liens repliés derrière le badge (le viewport mobile est compté).
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     setBadge(resolveEnvBadge(window.location.hostname));
@@ -39,28 +51,64 @@ export default function DevNav({ lang }: { lang: string }) {
 
   const linkClass =
     'text-slate-300 no-underline hover:text-teal-300 transition-colors';
+  const badgeClass =
+    'rounded bg-slate-800 px-1.5 py-0.5 font-mono text-[0.65rem] tracking-wide text-teal-300';
 
   return (
     <nav
       data-devnav
       aria-label="Navigation dev (hors production)"
-      // Desktop (md+) : barre pleine largeur EN HAUT (menu à gauche ; le zoom du CV
-      // court vient se placer à droite, cf. CvZoomSlider). Mobile : pastille en bas à
-      // droite (pas de conflit avec la barre d'outils mobile fixe en haut).
-      className="fixed bottom-3 right-3 z-[100] flex items-center gap-3 rounded-md border border-slate-700 bg-slate-900/90 px-3 py-1.5 text-xs font-medium shadow-lg backdrop-blur-sm print-preview:hidden print:hidden md:inset-x-0 md:bottom-auto md:top-0 md:h-10 md:rounded-none md:border-x-0 md:border-t-0 md:px-4 md:shadow-md"
+      // Toujours EN HAUT. Desktop (md+) : barre pleine largeur. Mobile : pastille
+      // en haut à gauche, hauteur alignée sur les boutons de la barre CV mobile
+      // (`--cv-toolbar-btn`, même padding-top safe-area que `HeaderToolbar`).
+      className="fixed left-3 top-[max(0.75rem,env(safe-area-inset-top,0px))] z-[100] flex h-[var(--cv-toolbar-btn)] items-center gap-3 rounded-md border border-slate-700 bg-slate-900/90 px-2.5 text-xs font-medium shadow-lg backdrop-blur-sm print-preview:hidden print:hidden md:inset-x-0 md:top-0 md:h-10 md:rounded-none md:border-x-0 md:border-t-0 md:px-4 md:shadow-md"
     >
-      <span className="rounded bg-slate-800 px-1.5 py-0.5 font-mono text-[0.65rem] tracking-wide text-teal-300">
-        {badge}
-      </span>
-      <a className={linkClass} href={`/${lang}/dev/renders`}>
-        Renders
-      </a>
-      <a className={linkClass} href={`/${lang}/dev/components`}>
-        Components
-      </a>
-      <a className={linkClass} href={`/${lang}/dev/llm-guide`}>
-        LLM guide
-      </a>
+      {/* Menu CV mobile ouvert (sélecteur de langue à gauche) → on s'efface
+          plutôt que de le recouvrir. Dev-only, borné mobile. */}
+      {/* Sans guillemets dans le sélecteur (`true` est un identifiant CSS valide) :
+          React échappe `"` en `&quot;` au SSR → mismatch d'hydratation sinon. */}
+      <style>{`@media (max-width: 767px){body:has(#cv-menu-toggle[aria-expanded=true]) [data-devnav]{display:none}}`}</style>
+
+      {/* < md : le badge est le bouton qui déplie/replie les liens. */}
+      <button
+        type="button"
+        className="flex items-center gap-1 md:hidden"
+        aria-expanded={open}
+        aria-controls="devnav-links"
+        aria-label={open ? 'Replier la navigation dev' : 'Navigation dev'}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className={badgeClass}>{badge}</span>
+        <svg
+          className={`h-3 w-3 text-slate-400 transition-transform ${
+            open ? 'rotate-180' : ''
+          }`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+      {/* md+ : badge simple (les liens sont toujours visibles). */}
+      <span className={`hidden md:inline-block ${badgeClass}`}>{badge}</span>
+
+      <div
+        id="devnav-links"
+        className={`items-center gap-3 md:flex ${open ? 'flex' : 'hidden'}`}
+      >
+        <a className={linkClass} href={`/${lang}/dev/renders`}>
+          Renders
+        </a>
+        <a className={linkClass} href={`/${lang}/dev/components`}>
+          Components
+        </a>
+        <a className={linkClass} href={`/${lang}/dev/llm-guide`}>
+          LLM guide
+        </a>
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
> Reprend #135 (fermée automatiquement au merge de #134 — base supprimée). Rebasée sur `main`.

## Quoi

La barre dev n'existait qu'en desktop (pleine largeur en haut) ; en mobile c'était une pastille en bas à droite, incohérente. **Un seul composant, toujours en haut, deux rendus selon le viewport** :

- **md+ (desktop / tablette)** : barre pleine largeur inchangée.
- **< md (mobile)** : pastille en haut à **gauche**, alignée sur la rangée de la barre d'outils CV (hauteur `--cv-toolbar-btn`, même safe-area, zone libre à gauche du burger). Le badge d'environnement (LOCAL / STAGING / PREVIEW) sert de **bouton** : replié = badge seul, déplié = badge + les mêmes liens Renders / Components / LLM guide.

## Choix de conception

- **Pas de couplage avec `HeaderToolbar`** : quand le menu CV mobile est ouvert (le sélecteur de langue arrive à gauche), la barre dev s'efface via `body:has(#cv-menu-toggle[aria-expanded=true])` — règle CSS bornée `max-width: 767px`, portée par le composant lui-même. Alternative écartée : décaler la barre d'outils CV sous une bande dev pleine largeur — trop de tentacules dans les régimes print/aperçu (risque de dérive WYSIWYG).
- Sélecteur **sans guillemets** (`true` est un identifiant CSS valide) : React échappe `\"` en `&quot;` au SSR → mismatch d'hydratation sinon.
- Les pages dev (renders, components, llm-guide) prennent un petit padding-top mobile pour dégager la pastille flottante.

## Vérifications
- `npm test` (prettier + lint) ✅
- Mobile 390px : pastille repliée/dépliée à côté du burger ✅ ; ouverture du menu CV → barre effacée (`display:none`) ✅
- Tablette 768px et desktop 1280px : barre pleine largeur en haut, identique à avant ✅
- Aucun impact print / `?print=1` (barre déjà `print:hidden` + `print-preview:hidden`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)