### PR TITLE
docs(features): fiche 0006 — ESLint 10 intégré au chantier Next (majeures ignorées côté Dependabot)

### DIFF
--- a/features/0006-migration-nextjs.md
+++ b/features/0006-migration-nextjs.md
@@ -27,6 +27,11 @@ Chantier dédié — plusieurs breaking changes :
   `tailwind.config.js` + `@apply`).
 - Les `@ts-expect-error Server Component` partout pourraient changer de comportement.
 - Turbopack par défaut (Next 15+), nouvelle API de cache (Next 16).
+- **ESLint 8 → 10 fait partie du chantier** : `eslint-config-next` de Next 14 exige
+  ESLint `^7 || ^8` — impossible de bumper avant Next 15+ (flat config). Les majeures
+  Next 16 et ESLint 10 sont **ignorées côté Dependabot** (`@dependabot ignore this major
+version`, PRs #60/#62/#83 fermées le 2026-07-05) : à la migration, bumper ESLint
+  manuellement.
 
 Plan suggéré :
 


### PR DESCRIPTION
Consigne dans la fiche **0006** (migration Next.js) deux décisions prises au tri des PRs Dependabot du 2026-07-05 :

- **ESLint 8 → 10 rejoint le chantier Next** : `eslint-config-next` de Next 14 exige ESLint `^7 || ^8` (vérifié dans `node_modules`), le bump est impossible avant Next 15+ (flat config).
- **Majeures ignorées côté Dependabot** : #60 (ESLint 10), #62 et #83 (Next 16) fermées via `@dependabot ignore this major version` — la migration se fera en branche dédiée, et il faudra penser à bumper ESLint manuellement à ce moment-là.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)