### PR TITLE
build(deps): bump @vercel/analytics 0.1.11 → 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "dependencies": {
         "@formatjs/intl-localematcher": "0.2.32",
-        "@vercel/analytics": "0.1.11",
+        "@vercel/analytics": "2.0.1",
         "eslint": "8.28.0",
         "intl-dateformat": "0.1.4",
         "negotiator": "0.6.3",
@@ -4680,11 +4680,45 @@
       }
     },
     "node_modules/@vercel/analytics": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-0.1.11.tgz",
-      "integrity": "sha512-mj5CPR02y0BRs1tN3oZcBNAX9a8NxsIUl9vElDPcqxnMfP0RbRc9fI9Ud7+QDg/1Izvt5uMumsr+6YsmVHcyuw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8||^17||^18"
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@formatjs/intl-localematcher": "0.2.32",
-    "@vercel/analytics": "0.1.11",
+    "@vercel/analytics": "2.0.1",
     "eslint": "8.28.0",
     "intl-dateformat": "0.1.4",
     "negotiator": "0.6.3",


### PR DESCRIPTION
## Contexte

Reprend la [PR Dependabot #63](https://github.com/elzinko/my-resume/pull/63) (ouverte en avril) : même après `@dependabot rebase`, son lockfile échouait au garde-fou CI « lockfile in sync » (le npm de Dependabot génère un lockfile différent du nôtre). Bump refait à la main avec le npm local — même approche que le lot #133.

## Changement

- `@vercel/analytics` **0.1.11 → 2.0.1** (épinglé exact, comme avant).
- Usage inchangé : unique `<Analytics />` importé de `@vercel/analytics/react` (`app/[lang]/layout.tsx:3`), API identique en v2.

## Vérification locale

- Lockfile **stable** au sens du check CI (`npm install --package-lock-only` ne le modifie plus).
- `npm run build` ✅ · `npm test` (prettier+lint) ✅ · `npm run test:unit` ✅

Remplace #63 (sera fermée en référence à cette PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)