### PR TITLE
chore(cv): retire le bloc mobile-only mort de CompactCvLayout (suite ADR-0006)

### DIFF
--- a/components/CompactCvLayout.tsx
+++ b/components/CompactCvLayout.tsx
@@ -208,35 +208,9 @@ export default function CompactCvLayout({
 
       {children}
 
-      {/* Mobile-only : Adéquation poste + Coordonnées, hors grille, avant Expérience. */}
-      <div className="space-y-[var(--cv-section-gap)] print:hidden md:hidden">
-        <Suspense fallback={null}>
-          <JobFitSection
-            lang={lang}
-            educationLevel={data.educationLevel}
-            variant="compact"
-            showEducationLevel={showEducationLevel}
-          />
-        </Suspense>
-        <section>
-          <SectionHeadingAts
-            section="contact"
-            locale={lang}
-            title={
-              data.titles.contact || (lang === 'fr' ? 'Coordonnées' : 'Contact')
-            }
-            accent="emerald"
-            className="min-w-0"
-          />
-          <ContactDisplay
-            contact={data.contact}
-            cvShortInlineRows
-            showLabels={false}
-            compact={true}
-            locale={lang}
-          />
-        </section>
-      </div>
+      {/* NB : le bloc mobile-only Adéquation+Coordonnées empilés (jadis `print:hidden md:hidden`)
+          a été retiré (ADR-0006 / my-resume#140) : `/short` ne rend plus JAMAIS CompactCvLayout
+          en mobile (le mobile affiche le CV complet via OfferTailoredShell), il était donc mort. */}
 
       {/* Colonne gauche 1/3 + expériences 2/3 (grille alignée sur les domaines) */}
       <div className="cv-page-split">


### PR DESCRIPTION
Petit nettoyage post-#140. Depuis la vue mobile indépendante, `/short` ne rend plus jamais `CompactCvLayout` en mobile (le mobile = CV complet via `OfferTailoredShell`). Son bloc **mobile-only** (`print:hidden md:hidden` : Adéquation + Coordonnées empilés) n'était donc **plus jamais affiché** → code mort, retiré.

- Desktop/impression **inchangé** (Adéquation + Coordonnées restent dans la grille `#left`).
- Bonus : retire un `JobFitSection` dupliqué → **réduit le doublon d'id** `#job-fit`.
- tsc + build OK ; **e2e 30 passed** (specs court desktop/print verts).

> NB : les `max-md:` de l'arbre A4 (OfferTailoredShell) ne sont PAS touchés — ils portent la vue mobile (réutilisation sûre). Le « clean » complet (MobileCv séparé + purge max-md:) reste un choix d'archi distinct, non retenu.