### PR TITLE
fix(cv): mobile — domaines Agile/Dev/Ops resserrés en sous-blocs du Profil

### DIFF
--- a/app/[lang]/about.tsx
+++ b/app/[lang]/about.tsx
@@ -22,7 +22,7 @@ export default async function About({
   return (
     <section
       id="about"
-      className="mb-1 mt-4 pb-1 print-preview:order-[10] print:order-[10] max-md:!mt-0"
+      className="mb-1 mt-4 pb-1 print-preview:order-[10] print:order-[10] max-md:!mt-0 max-md:mb-0"
     >
       <SectionHeadingAts
         section="about"

--- a/app/[lang]/domains.tsx
+++ b/app/[lang]/domains.tsx
@@ -16,10 +16,17 @@ export default async function domains({
   mode?: CvMode;
 }) {
   const data: any = await getCvData(locale);
+  // Mobile : les domaines sont des SOUS-blocs du Profil, pas une section sœur
+  // (même logique que le CV court, cf. CompactCvLayout `#domains`). Le margin-top
+  // négatif remplace le flex-gap inter-section (--cv-section-gap) par un body-gap :
+  // avec le body-gap propre au premier wrapper Domain, l'écart au-dessus d'« Agile »
+  // = 2 × --cv-section-body-gap (16px) = l'écart titre→texte et l'écart entre
+  // domaines (row-gap + body-gap). `max-md:mb-0` posé côté About pour ne pas
+  // fausser ce calcul.
   return (
     <section
       id="domains"
-      className="mt-2 print-preview:order-[20] print:order-[20] max-md:!mt-0"
+      className="mt-2 print-preview:order-[20] print:order-[20] max-md:!mt-[calc(var(--cv-section-body-gap)-var(--cv-section-gap))]"
     >
       {/* Ancre de section « Compétences / Skills » réservée à l'impression :
           à l'écran ce titre est porté par la sidebar `skills.tsx` (donc pas de

--- a/app/[lang]/short/page.tsx
+++ b/app/[lang]/short/page.tsx
@@ -233,11 +233,11 @@ export default async function ShortPage({
               sur mobile. On rend la vue COMPLÈTE (identique à `/[lang]`), sans redirect
               ni réécriture d'URL. Hors de l'enveloppe A4 → rendu mobile fidèle au complet.
               `renderEffects={false}` : effets déjà montés ci-dessus. */}
-          <div className="md:hidden print:hidden print-preview:hidden">
+          <div className="print-preview:hidden print:hidden md:hidden">
             <OfferTailoredShell {...fullShellProps} renderEffects={false} />
           </div>
           {/* DESKTOP + IMPRESSION (Cmd+P sans `?print`) — le CV court A4 (inchangé). */}
-          <div className="hidden md:block print:block print-preview:block">
+          <div className="hidden print-preview:block print:block md:block">
             {shortA4}
           </div>
         </>

--- a/e2e/cv-column-alignment.spec.ts
+++ b/e2e/cv-column-alignment.spec.ts
@@ -15,7 +15,9 @@ test.describe('CV court — alignement colonnes', () => {
   async function expectDevAlignedWithMain(
     page: import('@playwright/test').Page,
   ) {
-    const devCol = page.locator('.cv-short-page #domains .cv-domains-grid > *').nth(1);
+    const devCol = page
+      .locator('.cv-short-page #domains .cv-domains-grid > *')
+      .nth(1);
     const main = page.locator('#main');
 
     await expect(devCol).toBeVisible();
@@ -37,7 +39,9 @@ test.describe('CV court — alignement colonnes', () => {
   async function expectAgileAlignedWithLeft(
     page: import('@playwright/test').Page,
   ) {
-    const agileCol = page.locator('.cv-short-page #domains .cv-domains-grid > *').first();
+    const agileCol = page
+      .locator('.cv-short-page #domains .cv-domains-grid > *')
+      .first();
     const left = page.locator('#left');
 
     await expect(agileCol).toBeVisible();

--- a/e2e/mobile-section-spacing.spec.ts
+++ b/e2e/mobile-section-spacing.spec.ts
@@ -1,53 +1,96 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Rythme vertical mobile : les écarts entre sections EN FLUX (Profil → Domaines →
- * Adéquation poste) sont du même ordre (marges de section homogènes).
+ * Rythme vertical mobile : les domaines (Agile/Dev/Ops) sont des SOUS-blocs du
+ * Profil, pas des sections sœurs (même intention que le CV court, cf.
+ * short-cv-section-spacing). Trois invariants :
+ *
+ *   1. l'écart au-dessus de CHAQUE titre de domaine est identique
+ *      (Profil→Agile == Agile→Dev == Dev→Ops) ;
+ *   2. cet écart est du même ordre que l'écart titre→texte d'un domaine
+ *      (2 × --cv-section-body-gap ≈ mt-4 = 16px) ;
+ *   3. domaines → Adéquation poste reste un écart de SECTION (flex-gap
+ *      --cv-section-gap), nettement plus grand — c'est LUI qui marque le
+ *      changement de section, pas les titres de domaines.
  *
  * ⚠️ On ne compare PAS header → Profil : sous md, `.cv-full-cv-print-root` porte
  * `mt-20` (80px) de CLEARANCE pour la barre d'outils fixe — un écart volontairement
- * plus grand, pas du rythme de section. Le comparer au gap inter-section (~24px)
- * donnait un faux positif (ratio ~3,2). On mesure donc deux gaps inter-section
- * consécutifs, qui doivent rester homogènes.
+ * plus grand, pas du rythme de section.
  */
 test.describe('CV mobile vertical rhythm', () => {
   test.use({ viewport: { width: 375, height: 800 } });
 
-  test('about→domains et domains→adéquation : écarts du même ordre', async ({
+  test('domaines = sous-blocs du Profil : écarts uniformes ≈ titre→texte', async ({
     page,
   }) => {
     await page.goto('/fr');
 
     const about = page.locator('#about');
-    const domains = page.locator('#domains');
+    const items = page.locator('#domains .cv-domains-grid > div');
     const jobFit = page.locator('#job-fit');
 
     await expect(about).toBeVisible();
-    await expect(domains).toBeVisible();
+    await expect(items).toHaveCount(3);
     await expect(jobFit).toBeVisible();
 
-    const bottom = (loc: import('@playwright/test').Locator) =>
-      loc.evaluate((el) => el.getBoundingClientRect().bottom);
-    const top = (loc: import('@playwright/test').Locator) =>
-      loc.evaluate((el) => el.getBoundingClientRect().top);
+    const box = (loc: import('@playwright/test').Locator) =>
+      loc.evaluate((el) => {
+        const b = el.getBoundingClientRect();
+        return { top: b.top, bottom: b.bottom };
+      });
 
-    const aboutBottom = await bottom(about);
-    const domainsTop = await top(domains);
-    const domainsBottom = await bottom(domains);
-    const jobFitTop = await top(jobFit);
+    const aboutBox = await box(about);
+    const agile = await box(items.nth(0));
+    const dev = await box(items.nth(1));
+    const ops = await box(items.nth(2));
+    const jobFitBox = await box(jobFit);
 
-    const gapAboutDomains = domainsTop - aboutBottom;
-    const gapDomainsJobFit = jobFitTop - domainsBottom;
+    // Titres de domaines = haut du wrapper (le margin-top du wrapper porte le
+    // body-gap, donc le haut du BORDER-box == haut du titre).
+    const aboveAgile = agile.top - aboutBox.bottom;
+    const aboveDev = dev.top - agile.bottom;
+    const aboveOps = ops.top - dev.bottom;
 
-    expect(gapAboutDomains, 'about → domains').toBeGreaterThanOrEqual(12);
-    expect(gapDomainsJobFit, 'domains → job-fit').toBeGreaterThanOrEqual(12);
+    // 2. Référence : écart titre→texte du premier domaine (mt-4 de la description).
+    const agileTitle = items.nth(0).locator('h2');
+    const agileDesc = items.nth(0).locator('p');
+    const titleToText =
+      (await box(agileDesc)).top - (await box(agileTitle)).bottom;
 
-    const ratio =
-      Math.max(gapAboutDomains, gapDomainsJobFit) /
-      Math.min(gapAboutDomains, gapDomainsJobFit);
+    const gaps = [aboveAgile, aboveDev, aboveOps];
+    for (const gap of gaps) {
+      expect(
+        gap,
+        `gaps mesurés : ${gaps.map(Math.round).join(' / ')}px`,
+      ).toBeGreaterThanOrEqual(8);
+    }
+
+    // 1. Uniformité entre les trois écarts.
+    const spread = Math.max(...gaps) / Math.min(...gaps);
     expect(
-      ratio,
-      `Gaps should be similar (${gapAboutDomains}px vs ${gapDomainsJobFit}px)`,
-    ).toBeLessThanOrEqual(1.55);
+      spread,
+      `Écarts au-dessus des titres de domaines non uniformes (${gaps
+        .map(Math.round)
+        .join(' / ')}px)`,
+    ).toBeLessThanOrEqual(1.3);
+
+    // 2. Même ordre de grandeur que titre→texte.
+    const avg = gaps.reduce((a, b) => a + b, 0) / gaps.length;
+    const vsTitle = Math.max(avg, titleToText) / Math.min(avg, titleToText);
+    expect(
+      vsTitle,
+      `Écart au-dessus des domaines (${Math.round(
+        avg,
+      )}px) trop éloigné de titre→texte (${Math.round(titleToText)}px)`,
+    ).toBeLessThanOrEqual(1.35);
+
+    // 3. Le changement de SECTION (domaines → adéquation poste) reste marqué.
+    const sectionGap = jobFitBox.top - ops.bottom;
+    expect(
+      sectionGap,
+      `domains → job-fit (${Math.round(
+        sectionGap,
+      )}px) doit rester > écart de sous-bloc (${Math.round(avg)}px)`,
+    ).toBeGreaterThanOrEqual(avg * 1.2);
   });
 });

--- a/e2e/short-cv-section-spacing.spec.ts
+++ b/e2e/short-cv-section-spacing.spec.ts
@@ -47,7 +47,10 @@ test.describe('CV court — rythme vertical régulier', () => {
 
     const filet = await bbox(page, '#cv-short-about h2');
     const intro = await bbox(page, '#cv-short-about p');
-    const firstDomain = await bbox(page, '.cv-short-page #domains .cv-domains-grid h2');
+    const firstDomain = await bbox(
+      page,
+      '.cv-short-page #domains .cv-domains-grid h2',
+    );
 
     const filetToIntro = intro.top - filet.bottom;
     const introToDomains = firstDomain.top - intro.bottom;

--- a/lib/full-cv-shell-props.ts
+++ b/lib/full-cv-shell-props.ts
@@ -47,7 +47,8 @@ export async function buildFullCvShellProps(
       : undefined;
   const modeParam =
     typeof searchParams?.mode === 'string' ? searchParams.mode : undefined;
-  const mode: CvMode | undefined = modeParam === 'teaching' ? 'teaching' : undefined;
+  const mode: CvMode | undefined =
+    modeParam === 'teaching' ? 'teaching' : undefined;
   const { priorityTokens, contactLocation } = offerPriorityTokensAndContact(
     offer,
     sp,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -116,11 +116,14 @@
    * même gabarit horizontal que `.cv-page-split` (1/3 + 1/3 + 1/3).
    */
   .cv-domains-grid {
-    /* Mobile (empilé, 1 colonne) : `gap-y-7` → l'écart AU-DESSUS de Dev/Ops rejoint
-       celui au-dessus d'Agile (hérité du gap inter-blocs Profil→domaines) ⇒ rythme
-       régulier entre les 3 sous-domaines. En md+ et à l'impression, retour à 3 colonnes
-       (`gap-y-0`) : les titres sont côte à côte, donc déjà « au même niveau ». */
-    @apply grid w-full grid-cols-1 grid-rows-none gap-x-2 gap-y-7 md:grid-cols-3 md:items-stretch md:gap-x-10 md:gap-y-0;
+    /* Mobile (empilé, 1 colonne) : rythme de SOUS-bloc, pas de section — l'écart
+       visuel entre deux domaines = row-gap (--cv-section-body-gap) + le body-gap
+       propre du wrapper Domain suivant = 2 × body-gap (16px) ≈ l'écart titre→texte.
+       Même total au-dessus d'« Agile » via le margin-top négatif de `#domains`
+       (cf. domains.tsx) ⇒ Agile/Dev/Ops se lisent comme un groupe du Profil.
+       En md+ et à l'impression, retour à 3 colonnes (`gap-y-0`) : les titres sont
+       côte à côte, donc déjà « au même niveau ». */
+    @apply grid w-full grid-cols-1 grid-rows-none gap-x-2 gap-y-[var(--cv-section-body-gap)] md:grid-cols-3 md:items-stretch md:gap-x-10 md:gap-y-0;
     @apply print:grid print:grid-cols-3 print:items-stretch print:gap-x-4 print:gap-y-0;
   }
 


### PR DESCRIPTION
## Problème

Sur mobile, les domaines Agile/Dev/Ops du CV se lisaient comme des **sections autonomes** : 36px entre sous-domaines et 32px au-dessus d'« Agile », soit plus que l'écart entre vraies sections (~21px). En plus, l'écart au-dessus d'Agile (flex-gap inter-section) différait de celui au-dessus de Dev/Ops (row-gap de la grille) — la gestion était éclatée entre deux mécanismes.

## Fix (mobile web uniquement, token-driven)

Cible : **16px uniformes au-dessus de chaque titre de domaine** = l'écart titre→texte (`mt-4`). Même pattern que le CV court (`CompactCvLayout`) : les domaines sont des sous-blocs du Profil, pas des sections sœurs.

- `#domains` (complet) : `max-md:!mt-[calc(var(--cv-section-body-gap)-var(--cv-section-gap))]` — remplace le flex-gap inter-section par un body-gap.
- `#about` : `max-md:mb-0` (le `mb-1` faussait le calcul).
- `.cv-domains-grid` : `gap-y-[var(--cv-section-body-gap)]` sous md → écart entre domaines = row-gap + body-gap = 16px.

## Vérification (checklist 4 rendus + mobile)

Mesures Playwright :

| Rendu | Résultat |
|---|---|
| Complet **mobile** 390px (`/fr`, `/fr/short`) | 16/16/16px au-dessus d'Agile/Dev/Ops = titre→texte (16px) ; section suivante à 21px ✅ |
| Complet web 1280px | 3 colonnes, row-gap 0, marges inchangées ✅ |
| Complet aperçu `?print=1` | identique ✅ |
| Court web + court `?print=1` | grille/marges inchangées (`mt` token court −14.4px) ✅ |
| PDF | non affecté : page A4 ≥ 768px → variantes `md:`/`print:gap-y-0` actives |

- Suite e2e complète : **31 passed** (prod build, port 3457).
- `e2e/mobile-section-spacing.spec.ts` réécrite : l'ancienne assertion (about→domains ≈ domains→job-fit) encodait précisément le comportement corrigé.
- `npm test` (prettier + lint) ✅, `tsc --noEmit` ✅ — inclut un commit `style:` séparé : 4 fichiers de la PR #140 avaient été mergés non formatés (main était rouge sur `prettier:check`).

## Hors scope (préexistant)

Le test `@local-only` « En-tête : nom→rôle == rôle→âge » de `short-cv-section-spacing` échoue **aussi sur main** (débord de glyphe, sensible à la police locale, exclu de la CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)