### PR TITLE
test(e2e): gate le rythme d'en-tête /short + répare E2E rouge sur main (reflow zoom + scoping ADR-0006)

### DIFF
--- a/e2e/section-heading-filets.spec.ts
+++ b/e2e/section-heading-filets.spec.ts
@@ -24,14 +24,19 @@ test.describe('Filets de section — alignement (impression)', () => {
       document.documentElement.classList.add('cv-print-preview'),
     );
 
-    const bottomOf = (sel: string) =>
-      page
-        .locator(sel)
-        .first()
-        .evaluate((el) => Math.round(el.getBoundingClientRect().bottom));
-
-    const adequation = await bottomOf('#left #job-fit h2');
-    const experience = await bottomOf('#main > section h2');
+    // Sélecteurs scopés `.cv-short-page` (ADR-0006 : /short rend 2 arbres DOM en desktop)
+    // + les 2 bottoms mesurés dans UN SEUL `page.evaluate` (atomique). Le zoom du court est
+    // appliqué par JS (CvZoomSlider) après hydratation ; 2 mesures séparées peuvent enjamber
+    // ce reflow → bottoms lus à des zooms différents = désalignement fantôme (~100px observé
+    // sur le runner ubuntu, pas en local macOS). Cf. short-cv-section-spacing « En-tête ».
+    const { adequation, experience } = await page.evaluate(() => {
+      const bottom = (s: string) =>
+        Math.round(document.querySelector(s)!.getBoundingClientRect().bottom);
+      return {
+        adequation: bottom('.cv-short-page #left #job-fit h2'),
+        experience: bottom('.cv-short-page #main > section h2'),
+      };
+    });
 
     expect(
       Math.abs(adequation - experience),

--- a/e2e/short-cv-section-spacing.spec.ts
+++ b/e2e/short-cv-section-spacing.spec.ts
@@ -76,21 +76,47 @@ test.describe('CV court — rythme vertical régulier', () => {
   // Sélecteurs scopés `.cv-short-page` : depuis ADR-0006, /short rend 2 arbres DOM en
   // desktop ; sans scope, `.first()` tomberait sur le shell mobile caché → rect 0×0.
   test('En-tête : nom→rôle == rôle→âge (rythme uniforme)', async ({ page }) => {
-    // Desktop : c'est là que les marges divergeaient (rôle md:mt-3 vs âge md:mt-2).
     await page.setViewportSize({ width: 1024, height: 1400 });
+
+    const probe = async (label: string) => {
+      const d = await page.evaluate(() => {
+        const rect = (s: string) => {
+          const el = document.querySelector(s);
+          if (!el) return null;
+          const r = el.getBoundingClientRect();
+          return { top: r.top, bottom: r.bottom };
+        };
+        const sp = document.querySelector('.cv-short-page');
+        const cs = sp ? getComputedStyle(sp) : null;
+        const name = rect('.cv-short-page [data-cv-id="fullname"]');
+        const role = rect('.cv-short-page [data-cv-id="title"]');
+        const age = rect('.cv-short-page [data-cv-id="age"]');
+        return {
+          htmlClass: document.documentElement.className,
+          shortPageCount: document.querySelectorAll('.cv-short-page').length,
+          fullRootCount: document.querySelectorAll('.cv-full-cv-print-root')
+            .length,
+          zoom: cs ? (cs as unknown as { zoom?: string }).zoom : 'n/a',
+          name,
+          role,
+          age,
+          nameToRole: name && role ? role.top - name.bottom : null,
+          roleToAge: role && age ? age.top - role.bottom : null,
+        };
+      });
+      console.log(`[CIDIAG][${label}] ${JSON.stringify(d)}`);
+      return d;
+    };
+
     await page.goto(`/fr/short?${OFFER_QS}`);
+    await probe('noprint');
 
-    const name = await bbox(page, '.cv-short-page [data-cv-id="fullname"]');
-    const role = await bbox(page, '.cv-short-page [data-cv-id="title"]');
-    const age = await bbox(page, '.cv-short-page [data-cv-id="age"]');
+    await page.goto(`/fr/short?print=1&${OFFER_QS}`);
+    const d = await probe('print');
 
-    const nameToRole = role.top - name.bottom;
-    const roleToAge = age.top - role.bottom;
+    const nameToRole = d.nameToRole ?? -999;
+    const roleToAge = d.roleToAge ?? -999;
 
-    // En desktop, `/short` rend en typo A4 compacte (`.cv-print-preview` permanent
-    // + règles `min-width: 768px`) : les marges inter-lignes retombent à 2px → gaps
-    // ~1,6px. Le plancher garde juste des écarts POSITIFS et réels ; le vrai garde-fou
-    // est le ratio ci-dessous (rythme uniforme nom→rôle == rôle→âge).
     expect(nameToRole, 'nom → rôle').toBeGreaterThanOrEqual(1);
     expect(roleToAge, 'rôle → âge').toBeGreaterThanOrEqual(1);
     expect(

--- a/e2e/short-cv-section-spacing.spec.ts
+++ b/e2e/short-cv-section-spacing.spec.ts
@@ -47,7 +47,10 @@ test.describe('CV court — rythme vertical régulier', () => {
 
     const filet = await bbox(page, '#cv-short-about h2');
     const intro = await bbox(page, '#cv-short-about p');
-    const firstDomain = await bbox(page, '.cv-short-page #domains .cv-domains-grid h2');
+    const firstDomain = await bbox(
+      page,
+      '.cv-short-page #domains .cv-domains-grid h2',
+    );
 
     const filetToIntro = intro.top - filet.bottom;
     const introToDomains = firstDomain.top - intro.bottom;
@@ -64,37 +67,37 @@ test.describe('CV court — rythme vertical régulier', () => {
     ).toBeLessThanOrEqual(1.2);
   });
 
-  // @local-only : écarts entre lignes de texte (nom/rôle/âge) grignotés par le
-  // débord de glyphe → dépend de la police système (macOS ≠ ubuntu). Le ratio
-  // (rythme uniforme) reste vrai partout, mais les valeurs absolues divergent.
-  // Exclu de la CI (cf. .github/workflows/e2e.yml).
-  test(
-    'En-tête : nom→rôle == rôle→âge (rythme uniforme)',
-    { tag: '@local-only' },
-    async ({ page }) => {
-      // Desktop : c'est là que les marges divergeaient (rôle md:mt-3 vs âge md:mt-2).
-      await page.setViewportSize({ width: 1024, height: 1400 });
-      await page.goto(`/fr/short?${OFFER_QS}`);
+  // Gaps inter-lignes de l'en-tête : DÉTERMINISTES, indépendants de la police → GATÉS
+  // en CI (l'ancienne hypothèse « écarts grignotés par le débord de glyphe, macOS ≠
+  // ubuntu » était fausse). `getBoundingClientRect` mesure la BOÎTE de bloc, pas l'encre
+  // du glyphe ; les line-height sont toutes explicites (h1 1.25, p 1.375) et chaque écart
+  // = margin-top 0.125rem (2px, styles/globals.css) × zoom 0.82 = 1,625px — vérifié
+  // identique AU BIT PRÈS sur macOS ET ubuntu (conteneur Linux, 2026-07-07).
+  // Sélecteurs scopés `.cv-short-page` : depuis ADR-0006, /short rend 2 arbres DOM en
+  // desktop ; sans scope, `.first()` tomberait sur le shell mobile caché → rect 0×0.
+  test('En-tête : nom→rôle == rôle→âge (rythme uniforme)', async ({ page }) => {
+    // Desktop : c'est là que les marges divergeaient (rôle md:mt-3 vs âge md:mt-2).
+    await page.setViewportSize({ width: 1024, height: 1400 });
+    await page.goto(`/fr/short?${OFFER_QS}`);
 
-      const name = await bbox(page, '[data-cv-id="fullname"]');
-      const role = await bbox(page, '[data-cv-id="title"]');
-      const age = await bbox(page, '[data-cv-id="age"]');
+    const name = await bbox(page, '.cv-short-page [data-cv-id="fullname"]');
+    const role = await bbox(page, '.cv-short-page [data-cv-id="title"]');
+    const age = await bbox(page, '.cv-short-page [data-cv-id="age"]');
 
-      const nameToRole = role.top - name.bottom;
-      const roleToAge = age.top - role.bottom;
+    const nameToRole = role.top - name.bottom;
+    const roleToAge = age.top - role.bottom;
 
-      // En desktop, `/short` rend en typo A4 compacte (`.cv-print-preview` permanent
-      // + règles `min-width: 768px`) : les marges inter-lignes retombent à 2px → gaps
-      // ~1,6px. Le plancher garde juste des écarts POSITIFS et réels ; le vrai garde-fou
-      // est le ratio ci-dessous (rythme uniforme nom→rôle == rôle→âge).
-      expect(nameToRole, 'nom → rôle').toBeGreaterThanOrEqual(1);
-      expect(roleToAge, 'rôle → âge').toBeGreaterThanOrEqual(1);
-      expect(
-        ratio(nameToRole, roleToAge),
-        `gaps en-tête homogènes (${Math.round(nameToRole)}px vs ${Math.round(
-          roleToAge,
-        )}px)`,
-      ).toBeLessThanOrEqual(1.25);
-    },
-  );
+    // En desktop, `/short` rend en typo A4 compacte (`.cv-print-preview` permanent
+    // + règles `min-width: 768px`) : les marges inter-lignes retombent à 2px → gaps
+    // ~1,6px. Le plancher garde juste des écarts POSITIFS et réels ; le vrai garde-fou
+    // est le ratio ci-dessous (rythme uniforme nom→rôle == rôle→âge).
+    expect(nameToRole, 'nom → rôle').toBeGreaterThanOrEqual(1);
+    expect(roleToAge, 'rôle → âge').toBeGreaterThanOrEqual(1);
+    expect(
+      ratio(nameToRole, roleToAge),
+      `gaps en-tête homogènes (${Math.round(nameToRole)}px vs ${Math.round(
+        roleToAge,
+      )}px)`,
+    ).toBeLessThanOrEqual(1.25);
+  });
 });

--- a/e2e/short-cv-section-spacing.spec.ts
+++ b/e2e/short-cv-section-spacing.spec.ts
@@ -67,55 +67,36 @@ test.describe('CV court — rythme vertical régulier', () => {
     ).toBeLessThanOrEqual(1.2);
   });
 
-  // Gaps inter-lignes de l'en-tête : DÉTERMINISTES, indépendants de la police → GATÉS
-  // en CI (l'ancienne hypothèse « écarts grignotés par le débord de glyphe, macOS ≠
-  // ubuntu » était fausse). `getBoundingClientRect` mesure la BOÎTE de bloc, pas l'encre
-  // du glyphe ; les line-height sont toutes explicites (h1 1.25, p 1.375) et chaque écart
-  // = margin-top 0.125rem (2px, styles/globals.css) × zoom 0.82 = 1,625px — vérifié
-  // identique AU BIT PRÈS sur macOS ET ubuntu (conteneur Linux, 2026-07-07).
-  // Sélecteurs scopés `.cv-short-page` : depuis ADR-0006, /short rend 2 arbres DOM en
-  // desktop ; sans scope, `.first()` tomberait sur le shell mobile caché → rect 0×0.
+  // Gaps inter-lignes de l'en-tête : DÉTERMINISTES et indépendants de la police → GATÉS
+  // en CI (l'ancienne hypothèse « débord de glyphe, macOS ≠ ubuntu » était fausse ;
+  // `getBoundingClientRect` mesure la BOÎTE de bloc, pas l'encre du glyphe, et les
+  // line-height sont explicites). L'écart = margin-top 0.125rem (2px, styles/globals.css)
+  // × zoom (1 avant hydratation, 0.82 après CvZoomSlider) → toujours positif et homogène.
+  //
+  // DEUX précautions, sinon rouge sur le runner ubuntu (pas en local macOS) :
+  //  1. Sélecteurs scopés `.cv-short-page` — ADR-0006 : /short rend 2 arbres DOM en
+  //     desktop ; sans scope, `.first()` tombe sur le shell mobile caché → rect 0×0.
+  //  2. Les 3 rects mesurés dans UN SEUL `page.evaluate` (atomique). Le zoom du court est
+  //     appliqué par JS (CvZoomSlider) après hydratation : 3 mesures séparées peuvent
+  //     enjamber ce reflow (nom mesuré à zoom 1, rôle à zoom 0.82) → écart négatif
+  //     fantôme (~-6px observé en CI). Une passe synchrone fige un layout cohérent.
   test('En-tête : nom→rôle == rôle→âge (rythme uniforme)', async ({ page }) => {
     await page.setViewportSize({ width: 1024, height: 1400 });
-
-    const probe = async (label: string) => {
-      const d = await page.evaluate(() => {
-        const rect = (s: string) => {
-          const el = document.querySelector(s);
-          if (!el) return null;
-          const r = el.getBoundingClientRect();
-          return { top: r.top, bottom: r.bottom };
-        };
-        const sp = document.querySelector('.cv-short-page');
-        const cs = sp ? getComputedStyle(sp) : null;
-        const name = rect('.cv-short-page [data-cv-id="fullname"]');
-        const role = rect('.cv-short-page [data-cv-id="title"]');
-        const age = rect('.cv-short-page [data-cv-id="age"]');
-        return {
-          htmlClass: document.documentElement.className,
-          shortPageCount: document.querySelectorAll('.cv-short-page').length,
-          fullRootCount: document.querySelectorAll('.cv-full-cv-print-root')
-            .length,
-          zoom: cs ? (cs as unknown as { zoom?: string }).zoom : 'n/a',
-          name,
-          role,
-          age,
-          nameToRole: name && role ? role.top - name.bottom : null,
-          roleToAge: role && age ? age.top - role.bottom : null,
-        };
-      });
-      console.log(`[CIDIAG][${label}] ${JSON.stringify(d)}`);
-      return d;
-    };
-
     await page.goto(`/fr/short?${OFFER_QS}`);
-    await probe('noprint');
 
-    await page.goto(`/fr/short?print=1&${OFFER_QS}`);
-    const d = await probe('print');
-
-    const nameToRole = d.nameToRole ?? -999;
-    const roleToAge = d.roleToAge ?? -999;
+    const { nameToRole, roleToAge } = await page.evaluate(() => {
+      const bottomTop = (s: string) => {
+        const r = document.querySelector(s)!.getBoundingClientRect();
+        return { top: r.top, bottom: r.bottom };
+      };
+      const name = bottomTop('.cv-short-page [data-cv-id="fullname"]');
+      const role = bottomTop('.cv-short-page [data-cv-id="title"]');
+      const age = bottomTop('.cv-short-page [data-cv-id="age"]');
+      return {
+        nameToRole: role.top - name.bottom,
+        roleToAge: age.top - role.bottom,
+      };
+    });
 
     expect(nameToRole, 'nom → rôle').toBeGreaterThanOrEqual(1);
     expect(roleToAge, 'rôle → âge').toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
## Point de départ

Le test e2e « En-tête : nom→rôle == rôle→âge » de `short-cv-section-spacing.spec.ts`
était `@local-only` (exclu de la CI) au motif que l'écart inter-lignes dépendrait de
la police système (macOS ≠ ubuntu).

## Ce que la vérification a révélé

La justification « police » est **fausse** : l'écart est déterministe, positif et
homogène (`getBoundingClientRect` mesure la boîte de bloc, pas l'encre du glyphe ;
line-height explicites). **Mais** le test échouait bel et bien sur le runner
`ubuntu-latest` — pour **deux** bugs jamais reproductibles en local macOS **ni** dans
l'image Docker `playwright:v1.59.1-noble` (seul le vrai runner GitHub les révèle) :

1. **Scoping ADR-0006 (#140)** — `/short` rend 2 arbres DOM en desktop ; les sélecteurs
   non scopés → `.first()` sur le shell mobile caché → `rect 0×0`. *Fix : scoper
   `.cv-short-page`* (straggler du fix #140, passé inaperçu car le test était `@local-only`).

2. **Course au reflow de zoom** — `/short` applique le zoom du court par JS
   (`CvZoomSlider`) **après** hydratation (zoom 1 → 0.82). Mesurer les rects en plusieurs
   appels Playwright séparés fait **enjamber ce reflow** → rects lus à des zooms différents
   → écarts **fantômes** (`-6px` sur En-tête). *Fix : tout mesurer dans un seul
   `page.evaluate` (atomique).*

## Bonus : E2E était déjà ROUGE sur `main`

En poussant la branche d'essai, découverte que **le workflow E2E est rouge sur `main`
depuis ADR-0006 #140** (2026-07-06) à cause de `section-heading-filets.spec.ts` — **même
classe de bug** (sélecteurs `#main`/`#left` non scopés + mesures non atomiques enjambant
le reflow → désalignement fantôme de ~100px). Corrigé ici (scope `.cv-short-page` +
mesure atomique). **Merger cette PR reverdit donc aussi `main`.**

## Modifs

- `short-cv-section-spacing.spec.ts` (En-tête) : mesure atomique, sélecteurs scopés,
  retrait de `{ tag: '@local-only' }` → **gaté en CI**, commentaire réécrit.
- `section-heading-filets.spec.ts` : scope `.cv-short-page` + mesure atomique.

Le `--grep-invert "@local-only"` du workflow reste **inchangé** : `cv-row-alignment`
(comparaison de baseline, réellement dépendant des métriques de glyphes) garde le tag.

## Vérification

E2E **vert sur `ubuntu-latest`** : `31 passed`, dont `✓ En-tête` (désormais gaté) et
`✓ section-heading-filets`. Tous les checks de la PR au vert (e2e, build, CodeQL).

> Historique de branche : contient des commits `[diag]` intermédiaires (instrumentation
> jetable pour diagnostiquer sur le runner). À **squash-merger**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
