### PR TITLE
test(cv): fiabilise le test de rythme d'en-tête du CV court (@local-only)

### DIFF
--- a/app/[lang]/short/page.tsx
+++ b/app/[lang]/short/page.tsx
@@ -233,11 +233,11 @@ export default async function ShortPage({
               sur mobile. On rend la vue COMPLÈTE (identique à `/[lang]`), sans redirect
               ni réécriture d'URL. Hors de l'enveloppe A4 → rendu mobile fidèle au complet.
               `renderEffects={false}` : effets déjà montés ci-dessus. */}
-          <div className="md:hidden print:hidden print-preview:hidden">
+          <div className="print-preview:hidden print:hidden md:hidden">
             <OfferTailoredShell {...fullShellProps} renderEffects={false} />
           </div>
           {/* DESKTOP + IMPRESSION (Cmd+P sans `?print`) — le CV court A4 (inchangé). */}
-          <div className="hidden md:block print:block print-preview:block">
+          <div className="hidden print-preview:block print:block md:block">
             {shortA4}
           </div>
         </>

--- a/e2e/cv-column-alignment.spec.ts
+++ b/e2e/cv-column-alignment.spec.ts
@@ -15,7 +15,9 @@ test.describe('CV court — alignement colonnes', () => {
   async function expectDevAlignedWithMain(
     page: import('@playwright/test').Page,
   ) {
-    const devCol = page.locator('.cv-short-page #domains .cv-domains-grid > *').nth(1);
+    const devCol = page
+      .locator('.cv-short-page #domains .cv-domains-grid > *')
+      .nth(1);
     const main = page.locator('#main');
 
     await expect(devCol).toBeVisible();
@@ -37,7 +39,9 @@ test.describe('CV court — alignement colonnes', () => {
   async function expectAgileAlignedWithLeft(
     page: import('@playwright/test').Page,
   ) {
-    const agileCol = page.locator('.cv-short-page #domains .cv-domains-grid > *').first();
+    const agileCol = page
+      .locator('.cv-short-page #domains .cv-domains-grid > *')
+      .first();
     const left = page.locator('#left');
 
     await expect(agileCol).toBeVisible();

--- a/e2e/short-cv-section-spacing.spec.ts
+++ b/e2e/short-cv-section-spacing.spec.ts
@@ -47,7 +47,10 @@ test.describe('CV court — rythme vertical régulier', () => {
 
     const filet = await bbox(page, '#cv-short-about h2');
     const intro = await bbox(page, '#cv-short-about p');
-    const firstDomain = await bbox(page, '.cv-short-page #domains .cv-domains-grid h2');
+    const firstDomain = await bbox(
+      page,
+      '.cv-short-page #domains .cv-domains-grid h2',
+    );
 
     const filetToIntro = intro.top - filet.bottom;
     const introToDomains = firstDomain.top - intro.bottom;
@@ -76,9 +79,13 @@ test.describe('CV court — rythme vertical régulier', () => {
       await page.setViewportSize({ width: 1024, height: 1400 });
       await page.goto(`/fr/short?${OFFER_QS}`);
 
-      const name = await bbox(page, '[data-cv-id="fullname"]');
-      const role = await bbox(page, '[data-cv-id="title"]');
-      const age = await bbox(page, '[data-cv-id="age"]');
+      // Scope `.cv-short-page` OBLIGATOIRE : depuis ADR-0006, `/short` hors `?print`
+      // rend AUSSI l'arbre du CV complet (branche mobile, `md:hidden`) AVANT l'arbre
+      // A4 court → un `[data-cv-id]` nu matche d'abord le header caché du complet
+      // (rects 0×0 → gaps mesurés à 0, plancher cassé).
+      const name = await bbox(page, '.cv-short-page [data-cv-id="fullname"]');
+      const role = await bbox(page, '.cv-short-page [data-cv-id="title"]');
+      const age = await bbox(page, '.cv-short-page [data-cv-id="age"]');
 
       const nameToRole = role.top - name.bottom;
       const roleToAge = age.top - role.bottom;

--- a/lib/full-cv-shell-props.ts
+++ b/lib/full-cv-shell-props.ts
@@ -47,7 +47,8 @@ export async function buildFullCvShellProps(
       : undefined;
   const modeParam =
     typeof searchParams?.mode === 'string' ? searchParams.mode : undefined;
-  const mode: CvMode | undefined = modeParam === 'teaching' ? 'teaching' : undefined;
+  const mode: CvMode | undefined =
+    modeParam === 'teaching' ? 'teaching' : undefined;
   const { priorityTokens, contactLocation } = offerPriorityTokensAndContact(
     offer,
     sp,


### PR DESCRIPTION
## Contexte

Le test e2e `@local-only` « En-tête : nom→rôle == rôle→âge (rythme uniforme) » de `e2e/short-cv-section-spacing.spec.ts` échouait en local sur `main` (`nameToRole` mesuré à 0, plancher `>= 1` cassé).

## Diagnostic

Ce n'était **pas** le débord de glyphe de la police système (la piste documentée dans le commentaire du test). Depuis l'ADR-0006 (#140), `/short` **hors `?print`** rend **deux arbres React** dans le DOM : la vue complète mobile (`OfferTailoredShell`, cachée en desktop via `md:hidden`, rendue **en premier**) puis l'arbre A4 du court (`.cv-short-page`). Les sélecteurs `[data-cv-id]` nus + `.first()` matchaient le header **caché** du CV complet → `getBoundingClientRect` à 0×0 → gaps mesurés à 0.

Le rendu réel est intact : scopé à `.cv-short-page`, les écarts valent **1,625px / 1,625px** (marge explicite 2px × zoom A4 0,82), ratio = 1. Vérifié visuellement sur l'aperçu `?print=1` et la vue desktop — identiques, rythme régulier. **Aucune modif CSS nécessaire.**

## Changements

- **`test(cv)`** : les 3 sélecteurs du test d'en-tête scopés à `.cv-short-page`, avec un commentaire expliquant le piège des deux arbres. Plancher (1px) et ratio (1,25) inchangés — largement respectés (1,6px mesuré).
- **`style`** : reformatage prettier de 3 fichiers **déjà mal formatés sur `main`** (hérités du merge ADR-0006 : `app/[lang]/short/page.tsx`, `e2e/cv-column-alignment.spec.ts`, `lib/full-cv-shell-props.ts`) — `prettier:check` (donc `npm test`) échouait à cause d'eux. Aucun changement de comportement.

## Vérifications

- `npx playwright test short-cv-section-spacing` : **2/2 passed** (1/2 avant).
- Suite Playwright locale complète : **32 passed**.
- `npm test` (prettier:check + lint) : vert.

## Suivi

La justification du tag `@local-only` (sensibilité à la police système) semble invalidée : les mesures sont déterministes (marges et line-heights explicites). Le tag est laissé en place ; une tâche de suivi séparée évalue s'il peut réintégrer la CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
