### PR TITLE
fix(cv): poste + âge plus grands à l'impression (alignés sur le web, WYSIWYG)

### DIFF
--- a/components/HeaderContent.tsx
+++ b/components/HeaderContent.tsx
@@ -149,15 +149,17 @@ export default function HeaderContent({
             data-cv-id="title"
             className={
               compactPrint
-                ? // A4 : taille fixe = PDF (text-base, 16px), pas de bump md:.
-                  `${lineGap} text-base leading-none text-[#fca658]`
+                ? // A4 : taille fixe = PDF (text-lg, 18px), pas de bump md:. 18 > âge 16
+                  // → petite hiérarchie, cohérent avec le complet (24 > 20).
+                  `${lineGap} text-lg leading-none text-[#fca658]`
                 : `${lineGap} text-lg leading-snug text-[#fca658] md:leading-normal ${
                     photoUrl ? 'md:text-2xl' : 'md:text-3xl'
                   } ${
                     photoUrl
-                      ? // Bloc droit à 50 % : rôle nowrap + un cran plus petit pour tenir sur 1 ligne en PDF.
-                        'print:whitespace-nowrap print:text-xl print:leading-normal'
-                      : 'print:text-2xl print:leading-normal'
+                      ? // Bloc droit à 50 % : rôle nowrap. Taille print ALIGNÉE sur le web
+                        // (md:text-2xl = 24px) → WYSIWYG aperçu == PDF (avant : print 20px).
+                        'print:whitespace-nowrap print:text-2xl print:leading-normal'
+                      : 'print:text-3xl print:leading-normal'
                   }`
             }
           >
@@ -168,9 +170,12 @@ export default function HeaderContent({
               data-cv-id="age"
               className={
                 compactPrint
-                  ? // A4 : taille fixe = PDF (text-xs, 12px), pas de bump md:.
-                    `${lineGap} text-xs leading-none text-[#22c68d]`
-                  : `${lineGap} text-base leading-snug text-[#22c68d] print:text-base md:text-xl`
+                  ? // A4 : taille fixe = PDF (text-base, 16px). Avant text-xs (12px) →
+                    // trop petit ET incohérent avec l'aperçu (que la règle globals.css
+                    // 1198 forçait déjà à 16px) : on aligne l'élément sur l'aperçu.
+                    `${lineGap} text-base leading-none text-[#22c68d]`
+                  : // Print ALIGNÉ sur le web (md:text-xl = 20px) → WYSIWYG (avant 16px).
+                    `${lineGap} text-base leading-snug text-[#22c68d] print:text-xl md:text-xl`
               }
             >
               {ageText}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1197,8 +1197,15 @@ html {
 
   .cv-print-preview .cv-short-page .header-content p {
     margin-top: 0.125rem !important;
-    font-size: 1rem !important; /* text-base */
     line-height: 1.375 !important;
+  }
+  /* Aperçu = PDF : tailles PAR élément (poste 18px > âge 16px), au lieu d'aplatir
+     les deux à 16px (ce qui masquait l'âge réel du PDF, 12px avant). */
+  .cv-print-preview .cv-short-page .header-content p[data-cv-id='title'] {
+    font-size: 1.125rem !important; /* text-lg, 18px */
+  }
+  .cv-print-preview .cv-short-page .header-content p[data-cv-id='age'] {
+    font-size: 1rem !important; /* text-base, 16px */
   }
 
   /* Short print-preview : CORPS de texte aux tailles d'IMPRESSION (les utilitaires


### PR DESCRIPTION
Le poste et l'âge de l'en-tête étaient un poil petits en PDF. Plutôt qu'un bump print-only (qui aurait creusé l'écart aperçu↔PDF déjà présent), on **aligne les tailles print sur les tailles web** → plus grand en impression **et** WYSIWYG (aperçu == PDF) rétabli.

| | Avant (PDF) | Après (PDF) | = Web |
|---|---|---|---|
| Complet — poste | 20px | **24px** | ✅ |
| Complet — âge | 16px | **20px** | ✅ |
| Court — poste | 16px | **18px** | ✅ |
| Court — âge | 12px | **16px** | ✅ |

**Garanties**
- Vue web pure inchangée (seules les variantes `print:` modifiées côté complet).
- Nom inchangé.
- **CV court toujours 1 page A4** — test e2e `short-cv-one-page` vert (/fr + /en).
- Poste complet à 24px tient sur 1 ligne (vérifié au rendu print réel).
- L'override d'aperçu du court passe de « tout à 16px » à des tailles **par élément** → il ne masque plus l'âge réel du PDF (12px avant).

Rendus print vérifiés (poste/âge complet 24/20, court 18/16), 10 tests e2e header/1-page verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)