### PR TITLE
feat(cv): entrées « entreprise / poste / ville — période » sur 1 ligne (court + complet)

### DIFF
--- a/components/JobDisplay.tsx
+++ b/components/JobDisplay.tsx
@@ -46,7 +46,7 @@ function JobMetaMobileRow({
 
   return (
     <div
-      className={`flex w-full max-w-full items-baseline justify-between gap-x-3 print:hidden md:hidden ${typo}`}
+      className={`flex w-full max-w-full items-baseline justify-between gap-x-3 print-preview:hidden print:hidden md:hidden ${typo}`}
       data-testid="job-meta-mobile"
     >
       <span className="min-w-0 truncate text-left" data-job-meta="role">
@@ -189,8 +189,10 @@ export default function JobDisplay({
       {/* En-tête sur UNE ligne : « Entreprise / poste / ville » à gauche (entreprise en
           gras, poste+ville en normal), période SEULE à droite. Le poste+ville sont
           INLINE (desktop + print) ; sous md, la ligne mobile ci-dessous les porte.
-          `print:!inline` fait survivre poste/ville ET dates à @media print malgré
-          `max-md:hidden` (sinon un PDF rendu <768px les masquerait — cf. photo/dates). */}
+          `print:!inline` + `print-preview:!inline` font survivre poste/ville ET dates
+          en PDF réel ET en aperçu `.cv-print-preview` (où `print:` n'agit pas) malgré
+          `max-md:hidden` (sinon un rendu <768px les masquerait). La ligne mobile est en
+          plus `print-preview:hidden` → l'aperçu ne double PAS le poste (WYSIWYG <768). */}
       <div className="cv-row-with-side-meta pb-2">
         <span className="min-w-0 flex-1 text-base font-bold leading-snug text-cv-jobs print:text-sm">
           {job.clientUrl ? (
@@ -200,7 +202,7 @@ export default function JobDisplay({
           ) : (
             job.client
           )}
-          <span className="font-normal print:!inline max-md:hidden">
+          <span className="font-normal print-preview:!inline print:!inline max-md:hidden">
             {roleName ? ` / ${roleName}` : ''}
             {showRoleAts ? (
               <span className="italic opacity-70">{` · ${roleNameEn}`}</span>
@@ -208,7 +210,7 @@ export default function JobDisplay({
             {job.location ? ` / ${job.location}` : ''}
           </span>
         </span>
-        <span className="min-w-max shrink-0 self-end text-cv-meta font-normal tabular-nums leading-snug text-cv-jobs print:!inline print:text-xs max-md:hidden">
+        <span className="min-w-max shrink-0 self-end text-cv-meta font-normal tabular-nums leading-snug text-cv-jobs print-preview:!inline print:!inline print:text-xs max-md:hidden">
           {dates}
         </span>
       </div>

--- a/components/JobDisplay.tsx
+++ b/components/JobDisplay.tsx
@@ -123,9 +123,9 @@ export default function JobDisplay({
     );
     return (
       <div>
-        {/* En-tête compact sur UNE SEULE ligne : « Client / Rôle » à gauche,
-            « Lieu / Dates » à droite. Client en gras, le reste plus petit
-            (text-cv-meta). Tient en print, desktop ET mobile (truncation). */}
+        {/* En-tête compact sur UNE SEULE ligne : « Client / Rôle / Ville » à gauche,
+            période SEULE à droite (cohérent avec Études/Projets : que des dates à droite).
+            Client en gras, le reste plus petit. Gauche en `truncate` → toujours 1 ligne. */}
         <div className="cv-row-with-side-meta items-baseline gap-x-2 leading-tight print:leading-tight">
           <span className="min-w-0 flex-1 truncate text-left">
             <span className="text-[12px] font-bold leading-tight text-cv-jobs">
@@ -146,9 +146,13 @@ export default function JobDisplay({
                 {` / ${roleName}`}
               </span>
             ) : null}
+            {job.location ? (
+              <span className="text-[12px] font-normal leading-tight text-cv-jobs">
+                {` / ${job.location}`}
+              </span>
+            ) : null}
           </span>
           <span className="min-w-max shrink-0 whitespace-nowrap text-right text-[12px] font-normal tabular-nums leading-tight text-cv-jobs">
-            {job.location ? `${job.location} / ` : ''}
             {compactDateLine}
           </span>
         </div>
@@ -182,7 +186,12 @@ export default function JobDisplay({
 
   return (
     <div id={slugifyClient(job.client)}>
-      <div className="cv-row-with-side-meta">
+      {/* En-tête sur UNE ligne : « Entreprise / poste / ville » à gauche (entreprise en
+          gras, poste+ville en normal), période SEULE à droite. Le poste+ville sont
+          INLINE (desktop + print) ; sous md, la ligne mobile ci-dessous les porte.
+          `print:!inline` fait survivre poste/ville ET dates à @media print malgré
+          `max-md:hidden` (sinon un PDF rendu <768px les masquerait — cf. photo/dates). */}
+      <div className="cv-row-with-side-meta pb-2">
         <span className="min-w-0 flex-1 text-base font-bold leading-snug text-cv-jobs print:text-sm">
           {job.clientUrl ? (
             <a href={job.clientUrl} target="_blank" rel="noopener noreferrer">
@@ -191,23 +200,19 @@ export default function JobDisplay({
           ) : (
             job.client
           )}
+          <span className="font-normal print:!inline max-md:hidden">
+            {roleName ? ` / ${roleName}` : ''}
+            {showRoleAts ? (
+              <span className="italic opacity-70">{` · ${roleNameEn}`}</span>
+            ) : null}
+            {job.location ? ` / ${job.location}` : ''}
+          </span>
         </span>
         <span className="min-w-max shrink-0 self-end text-cv-meta font-normal tabular-nums leading-snug text-cv-jobs print:!inline print:text-xs max-md:hidden">
           {dates}
         </span>
       </div>
       <JobMetaMobileRow roleName={roleName} datesLine={datesStr} />
-      <div className="cv-row-with-side-meta pb-2 print:flex max-md:hidden">
-        <span className="min-w-0 flex-1 text-cv-meta font-normal leading-snug text-cv-jobs print:text-xs">
-          {roleName ?? ''}
-          {showRoleAts ? (
-            <span className="italic opacity-70">{` · ${roleNameEn}`}</span>
-          ) : null}
-        </span>
-        <span className="min-w-max shrink-0 self-end text-cv-meta leading-snug text-cv-jobs print:text-xs">
-          {job.location}
-        </span>
-      </div>
       <JobExperienceBody
         descriptionShort={job.descriptionShort}
         description={job.description}


### PR DESCRIPTION
Uniformise l'en-tête des expériences : **gauche = « entreprise / poste / ville »** (entreprise en gras), **droite = période seule** — cohérent avec Études/Projets (que des dates à droite).

### CV court (#2)
La ville passe de la **droite** (collée à la date) à la **gauche**, après le poste. Bloc gauche en `truncate` → toujours 1 ligne.
- ✅ Aucune troncature sur les 8 entrées (même « Matière Web / Co-founder & Director / Melun, France »).
- ✅ Toujours **1 page A4**.

### CV complet (#3)
Le poste + la ville vivaient sur une **2e ligne masquée à l'impression** (`max-md:hidden` battait `print:flex` → le PDF ne montrait que « entreprise — période »). Ils passent **inline** après l'entreprise sur la ligne 1, en `print:!inline` (survit à `@media print` même <768px, cf. dates/photo). La ligne mobile (poste + dates) est inchangée.
- ✅ 1 ligne pour toutes les entrées.
- ✅ Visible en **print ET desktop web** (WYSIWYG). Mobile : layout adaptatif inchangé.

Rendus print + web + mobile vérifiés (captures ci-jointes en local), **13 tests e2e verts** (1 page fr/en, lignes mobiles, liens clients, print-layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)