### PR TITLE
feat(cv): dates pour Learnings & Hobbies (« depuis AAAA » / année, à droite comme Projets)

### DIFF
--- a/components/HobbiesDisplay.tsx
+++ b/components/HobbiesDisplay.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import CustomLink from '@/components/CustomLink';
 import SectionHeadingAts from '@/components/SectionHeadingAts';
+import { formatEntryPeriod } from '@/lib/date';
 import type { Locale } from 'i18n-config';
 
 export interface HobbyItem {
@@ -10,6 +11,8 @@ export interface HobbyItem {
   name: string;
   link: string;
   description?: string;
+  startDate?: string;
+  endDate?: string | null;
 }
 
 interface HobbiesDisplayProps {
@@ -31,21 +34,37 @@ export default function HobbiesDisplay({
         title={title}
         accent="orange"
       />
-      <ul className="cv-section-simple-list cv-cq-link-list max-md:mt-6">
-        {items.map((hobby) => (
-          <li className="text-orange-300" key={hobby.id}>
-            <CustomLink
-              name={hobby.name}
-              link={hobby.link}
-              className="text-orange-300 print:!text-orange-300"
-            />
-            {hobby.description ? (
-              <span className="cv-hobby-desc ml-1 text-sm text-cv-body-muted">
-                · {hobby.description}
+      <ul className="cv-section-simple-list max-md:mt-6">
+        {items.map((hobby) => {
+          // Période « depuis AAAA » collée à droite (slot `year` de `.cv-entry`),
+          // comme Projets/Études : loisir = activité en cours → fin ouverte.
+          const period = formatEntryPeriod(
+            hobby.startDate,
+            hobby.endDate,
+            locale,
+          );
+          return (
+            <li className="cv-entry text-orange-300" key={hobby.id}>
+              <span className="cv-entry-title">
+                <CustomLink
+                  name={hobby.name}
+                  link={hobby.link}
+                  className="text-orange-300 print:!text-orange-300"
+                />
               </span>
-            ) : null}
-          </li>
-        ))}
+              {period ? (
+                <span className="cv-entry-year tabular-nums text-orange-300 print:!text-orange-300">
+                  {period}
+                </span>
+              ) : null}
+              {hobby.description ? (
+                <span className="cv-entry-detail cv-hobby-desc text-sm text-cv-body-muted">
+                  {hobby.description}
+                </span>
+              ) : null}
+            </li>
+          );
+        })}
       </ul>
     </>
   );

--- a/components/HobbiesDisplay.tsx
+++ b/components/HobbiesDisplay.tsx
@@ -52,14 +52,15 @@ export default function HobbiesDisplay({
                   className="text-orange-300 print:!text-orange-300"
                 />
               </span>
-              {period ? (
-                <span className="cv-entry-year tabular-nums text-orange-300 print:!text-orange-300">
-                  {period}
-                </span>
-              ) : null}
               {hobby.description ? (
                 <span className="cv-entry-detail cv-hobby-desc text-sm text-cv-body-muted">
                   {hobby.description}
+                </span>
+              ) : null}
+              {/* Année APRÈS le détail (ordre DOM cohérent avec Études). */}
+              {period ? (
+                <span className="cv-entry-year tabular-nums text-orange-300 print:!text-orange-300">
+                  {period}
                 </span>
               ) : null}
             </li>

--- a/components/LearningsDisplay.tsx
+++ b/components/LearningsDisplay.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import CustomLink from '@/components/CustomLink';
 import SectionHeadingAts from '@/components/SectionHeadingAts';
 import { learningLinkLabel } from '@/lib/learning-label';
+import { formatEntryPeriod } from '@/lib/date';
 import type { Locale } from 'i18n-config';
 
 export interface LearningItem {
@@ -11,6 +12,8 @@ export interface LearningItem {
   name: string;
   link: string;
   description?: string;
+  startDate?: string;
+  endDate?: string | null;
 }
 
 interface LearningsDisplayProps {
@@ -33,24 +36,37 @@ export default function LearningsDisplay({
         accent="teal"
       />
       <ul className="cv-section-simple-list max-md:mt-6">
-        {items.map((learning) => (
-          // Pas d'année pour les apprentissages : titre (L1) puis détail (L2 sans
-          // tiret) en mobile ; inline « titre — détail » en desktop/print (.cv-entry).
-          <li className="cv-entry text-teal-300" key={learning.id}>
-            <span className="cv-entry-title">
-              <CustomLink
-                name={learningLinkLabel(learning)}
-                link={learning.link}
-                className="text-teal-300 print:!text-teal-300"
-              />
-            </span>
-            {learning.description ? (
-              <span className="cv-entry-detail text-sm text-cv-body-muted">
-                {learning.description}
+        {items.map((learning) => {
+          // Année d'apprentissage collée à droite (slot `year` de `.cv-entry`),
+          // « depuis AAAA » si en cours (ex. LLM). Titre (L1) puis détail (L2) en
+          // mobile ; inline « titre — détail · année » en desktop/print (.cv-entry).
+          const period = formatEntryPeriod(
+            learning.startDate,
+            learning.endDate,
+            locale,
+          );
+          return (
+            <li className="cv-entry text-teal-300" key={learning.id}>
+              <span className="cv-entry-title">
+                <CustomLink
+                  name={learningLinkLabel(learning)}
+                  link={learning.link}
+                  className="text-teal-300 print:!text-teal-300"
+                />
               </span>
-            ) : null}
-          </li>
-        ))}
+              {period ? (
+                <span className="cv-entry-year tabular-nums text-teal-300 print:!text-teal-300">
+                  {period}
+                </span>
+              ) : null}
+              {learning.description ? (
+                <span className="cv-entry-detail text-sm text-cv-body-muted">
+                  {learning.description}
+                </span>
+              ) : null}
+            </li>
+          );
+        })}
       </ul>
     </>
   );

--- a/components/LearningsDisplay.tsx
+++ b/components/LearningsDisplay.tsx
@@ -54,14 +54,17 @@ export default function LearningsDisplay({
                   className="text-teal-300 print:!text-teal-300"
                 />
               </span>
-              {period ? (
-                <span className="cv-entry-year tabular-nums text-teal-300 print:!text-teal-300">
-                  {period}
-                </span>
-              ) : null}
               {learning.description ? (
                 <span className="cv-entry-detail text-sm text-cv-body-muted">
                   {learning.description}
+                </span>
+              ) : null}
+              {/* Année APRÈS le détail (ordre DOM = titre → détail → année, comme
+                  Études) : sans effet en grille (slot `year`), correct si un jour
+                  l'entrée passe inline (le `·` s'attache à l'année, pas au détail). */}
+              {period ? (
+                <span className="cv-entry-year tabular-nums text-teal-300 print:!text-teal-300">
+                  {period}
                 </span>
               ) : null}
             </li>

--- a/data/cv/experience.json
+++ b/data/cv/experience.json
@@ -714,51 +714,71 @@
   "hobbies": [
     {
       "id": "81779577",
-      "link": "https://docs.cycling74.com/legacy/max8/vignettes/live_object_model"
+      "link": "https://docs.cycling74.com/legacy/max8/vignettes/live_object_model",
+      "startDate": "2001-01-01",
+      "endDate": null
     },
     {
       "id": "81779962",
-      "link": "https://www.nba.com/stats/"
+      "link": "https://www.nba.com/stats/",
+      "startDate": "1985-01-01",
+      "endDate": null
     },
     {
       "id": "81780862",
-      "link": "https://www.passportesdusoleil.com/"
+      "link": "https://www.passportesdusoleil.com/",
+      "startDate": "1997-01-01",
+      "endDate": null
     },
     {
       "id": "81781610",
-      "link": "https://www.chess.com/fr"
+      "link": "https://www.chess.com/fr",
+      "startDate": "2021-01-01",
+      "endDate": null
     }
   ],
   "learnings": [
     {
       "id": "cnZskAq6SqSbkXAmAB0KIQ",
       "name": "LLM",
-      "link": "https://www.langchain.com/"
+      "link": "https://www.langchain.com/",
+      "startDate": "2022-01-01",
+      "endDate": null
     },
     {
       "id": "Taq3bWZ6Stu5rt42dP1_WQ",
       "name": "AWS Bedrock",
-      "link": "https://aws.amazon.com/fr/bedrock/agents/"
+      "link": "https://aws.amazon.com/fr/bedrock/agents/",
+      "startDate": "2025-01-01",
+      "endDate": "2025-01-01"
     },
     {
       "id": "UsM_i8jNSFK12ePhrc0x0g",
       "name": "MCP",
-      "link": "https://modelcontextprotocol.io/specification/2025-06-18"
+      "link": "https://modelcontextprotocol.io/specification/2025-06-18",
+      "startDate": "2025-01-01",
+      "endDate": "2025-01-01"
     },
     {
       "id": "learn-langchain-stack",
       "name": "LangChain",
-      "link": "https://docs.langchain.com/"
+      "link": "https://docs.langchain.com/",
+      "startDate": "2025-01-01",
+      "endDate": "2025-01-01"
     },
     {
       "id": "learn-openrag",
       "name": "OpenRAG",
-      "link": "https://docs.openr.ag/"
+      "link": "https://docs.openr.ag/",
+      "startDate": "2025-01-01",
+      "endDate": "2025-01-01"
     },
     {
       "id": "learn-bmad-method",
       "name": "BMAD",
-      "link": "https://docs.bmad-method.org/"
+      "link": "https://docs.bmad-method.org/",
+      "startDate": "2025-01-01",
+      "endDate": "2025-01-01"
     }
   ]
 }

--- a/lib/cv-compose.ts
+++ b/lib/cv-compose.ts
@@ -72,12 +72,18 @@ export interface ExperienceProject {
 export interface ExperienceHobby {
   id: string;
   link?: string;
+  /** Pratiqué DEPUIS cette date (fin ouverte) → période « depuis AAAA ». */
+  startDate?: string;
+  endDate?: string | null;
 }
 
 export interface ExperienceLearning {
   id: string;
   name: string;
   link?: string;
+  /** Année d'apprentissage (endDate == startDate) ou « depuis AAAA » si fin ouverte. */
+  startDate?: string;
+  endDate?: string | null;
 }
 
 export interface Experience {
@@ -259,6 +265,8 @@ export function composeCvSnapshot(
       description: lh.description,
     };
     if (eh.link !== undefined) out.link = eh.link;
+    if (eh.startDate !== undefined) out.startDate = eh.startDate;
+    if (eh.endDate !== undefined) out.endDate = eh.endDate;
     return out;
   });
 
@@ -270,6 +278,8 @@ export function composeCvSnapshot(
       name: el.name,
     };
     if (el.link !== undefined) out.link = el.link;
+    if (el.startDate !== undefined) out.startDate = el.startDate;
+    if (el.endDate !== undefined) out.endDate = el.endDate;
     out.description = ll.description;
     return out;
   });

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -32,6 +32,25 @@ export function formatJobDatesFull(
   return `${startStr} - ${endStr}`;
 }
 
+/**
+ * Période d'une entrée « liste » (Apprentissages / Loisirs), à l'ANNÉE :
+ * - fin ouverte (endDate absent/null) → « depuis AAAA » / « since YYYY » (en cours) ;
+ * - année unique (start == end)       → « AAAA » ;
+ * - sinon                             → « AAAA - AAAA ».
+ * Localisé : le libellé « depuis / since » suit la langue du CV.
+ */
+export function formatEntryPeriod(
+  startDate: string | null | undefined,
+  endDate: string | null | undefined,
+  locale: 'fr' | 'en' = 'fr',
+): string | null {
+  const sy = startDate ? new Date(startDate).getFullYear() : null;
+  const ey = endDate ? new Date(endDate).getFullYear() : null;
+  if (sy && !ey) return locale === 'en' ? `since ${sy}` : `depuis ${sy}`;
+  if (sy && ey) return sy === ey ? `${ey}` : `${sy} - ${ey}`;
+  return ey ? `${ey}` : null;
+}
+
 /** Année–année ou « YYYY - Présent » : CV court / impression (évite 2023-01-01 brut). */
 export function formatJobDatesCompactYears(
   start: string,

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -44,8 +44,8 @@ export function formatEntryPeriod(
   endDate: string | null | undefined,
   locale: 'fr' | 'en' = 'fr',
 ): string | null {
-  const sy = startDate ? new Date(startDate).getFullYear() : null;
-  const ey = endDate ? new Date(endDate).getFullYear() : null;
+  const sy = startDate ? yearFromIso(startDate) : null;
+  const ey = endDate ? yearFromIso(endDate) : null;
   if (sy && !ey) return locale === 'en' ? `since ${sy}` : `depuis ${sy}`;
   if (sy && ey) return sy === ey ? `${ey}` : `${sy} - ${ey}`;
   return ey ? `${ey}` : null;
@@ -71,10 +71,13 @@ export function formatJobDatesCompactYears(
   return `${sy} - ${ey}`;
 }
 
+// Année depuis une chaîne ISO `YYYY-…` SANS `new Date` : `new Date('2025-01-01')`
+// est minuit UTC et `.getFullYear()` re-projette en local → en fuseau négatif
+// (America/*) l'année tombe à 2024 (et mismatch d'hydratation). On lit les 4
+// chiffres de tête : fiable et indépendant du fuseau.
 function yearFromIso(s: string): string | null {
-  const d = new Date(s);
-  if (Number.isNaN(d.getTime())) return null;
-  return String(d.getFullYear());
+  const m = /^\s*(\d{4})/.exec(String(s));
+  return m ? m[1] : null;
 }
 
 /**


### PR DESCRIPTION
Historise les **Apprentissages** et **Loisirs** : période colorée collée à droite, comme Études/Projets.

### Donnée (métadonnée de l'entrée)
`startDate`/`endDate` ajoutés sur chaque entrée dans `data/cv/experience.json` (à côté de `id`/`link`), exactement comme `projects`/`studies`. Loisirs = **fin ouverte** (`endDate: null`).

### Format — `formatEntryPeriod` (lib/date.ts), localisé
- fin ouverte → **« depuis AAAA »** / **« since YYYY »** (en cours) ;
- année unique (start == end) → **« AAAA »**.

### Affichage
- **Learnings** : slot `year` de `.cv-entry` (déjà utilisé), teal.
- **Hobbies** : passent au layout `.cv-entry` (titre / année / détail) comme Learnings → période à droite (suite du chantier `?entriesLayout`), orange.

Valeurs : Ableton *depuis 2001* · Crossovers *1985* · Riding *1997* · échecs *2021* · LLM *depuis 2022* (début ChatGPT) · AWS Bedrock/MCP/LangChain/OpenRAG/BMAD *2025*.

**Full-CV uniquement** (le court n'affiche pas ces sections) → court toujours 1 page. Rendu fr+en (web + print) vérifié ; lint + tsc + 5 e2e verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)