### PR TITLE
fix(cv): Education sur 2 lignes par défaut (comme Projets/Learnings/Loisirs)

### DIFF
--- a/components/OfferTailoredShell.tsx
+++ b/components/OfferTailoredShell.tsx
@@ -45,7 +45,7 @@ export default function OfferTailoredShell({
   headerAlign = 'left',
   detailLevel = 'full',
   maxJobShown = null,
-  entriesLayout = 'inline',
+  entriesLayout = 'stacked',
   renderEffects = true,
 }: {
   lang: Locale;

--- a/lib/cv-entries-layout.ts
+++ b/lib/cv-entries-layout.ts
@@ -2,22 +2,23 @@
  * Disposition des entrées de liste « Études / Loisirs » (et sections `.cv-entry`
  * qui l'adoptent), pilotée par le paramètre d'URL `?entriesLayout`.
  *
- * - `inline` (DÉFAUT) : titre + détail sur UNE ligne, année collée à droite
- *   (desktop + impression). Sous `md`, repli automatique sur la grille 2 lignes
- *   (lisibilité mobile) — géré en CSS, pas ici.
- * - `stacked` : titre (+ année à droite) sur la ligne 1, détail sur la ligne 2,
- *   dans tous les régimes (ancien comportement « école sur la 2e ligne »).
+ * - `stacked` (DÉFAUT) : titre (+ année à droite) sur la ligne 1, détail sur la
+ *   ligne 2, dans tous les régimes — COHÉRENT avec Projets/Learnings/Loisirs (qui
+ *   utilisent la grille `.cv-entry` de base). C'est le rendu attendu par défaut.
+ * - `inline` (`?entriesLayout=inline`) : titre + détail sur UNE ligne, année
+ *   collée à droite (desktop + impression). Sous `md`, repli auto sur la grille
+ *   2 lignes (lisibilité mobile) — géré en CSS, pas ici.
  *
  * Paramètre UNIQUE et partagé (cf. décision produit) : la même valeur pilote
  * toutes les sections qui l'acceptent, pour un rendu cohérent.
  */
 export type EntriesLayout = 'inline' | 'stacked';
 
-export const DEFAULT_ENTRIES_LAYOUT: EntriesLayout = 'inline';
+export const DEFAULT_ENTRIES_LAYOUT: EntriesLayout = 'stacked';
 
-/** `?entriesLayout=stacked` → 'stacked' ; tout le reste (absent inclus) → 'inline'. */
+/** `?entriesLayout=inline` → 'inline' ; tout le reste (absent inclus) → 'stacked'. */
 export function parseEntriesLayout(
   value: string | null | undefined,
 ): EntriesLayout {
-  return value?.trim().toLowerCase() === 'stacked' ? 'stacked' : 'inline';
+  return value?.trim().toLowerCase() === 'inline' ? 'inline' : 'stacked';
 }

--- a/lib/cv-entries-layout.unit.test.ts
+++ b/lib/cv-entries-layout.unit.test.ts
@@ -5,17 +5,17 @@ import {
   DEFAULT_ENTRIES_LAYOUT,
 } from './cv-entries-layout';
 
-test('parseEntriesLayout : stacked (insensible à la casse / espaces)', () => {
-  assert.equal(parseEntriesLayout('stacked'), 'stacked');
-  assert.equal(parseEntriesLayout('STACKED'), 'stacked');
-  assert.equal(parseEntriesLayout('  Stacked  '), 'stacked');
+test('parseEntriesLayout : inline (insensible à la casse / espaces)', () => {
+  assert.equal(parseEntriesLayout('inline'), 'inline');
+  assert.equal(parseEntriesLayout('INLINE'), 'inline');
+  assert.equal(parseEntriesLayout('  Inline  '), 'inline');
 });
 
-test('parseEntriesLayout : défaut inline (absent / vide / inconnu)', () => {
-  assert.equal(DEFAULT_ENTRIES_LAYOUT, 'inline');
-  assert.equal(parseEntriesLayout('inline'), 'inline');
-  assert.equal(parseEntriesLayout(null), 'inline');
-  assert.equal(parseEntriesLayout(undefined), 'inline');
-  assert.equal(parseEntriesLayout(''), 'inline');
-  assert.equal(parseEntriesLayout('whatever'), 'inline');
+test('parseEntriesLayout : défaut stacked (absent / vide / inconnu / stacked)', () => {
+  assert.equal(DEFAULT_ENTRIES_LAYOUT, 'stacked');
+  assert.equal(parseEntriesLayout('stacked'), 'stacked');
+  assert.equal(parseEntriesLayout(null), 'stacked');
+  assert.equal(parseEntriesLayout(undefined), 'stacked');
+  assert.equal(parseEntriesLayout(''), 'stacked');
+  assert.equal(parseEntriesLayout('whatever'), 'stacked');
 });


### PR DESCRIPTION
Le bloc **Études** était la seule section d'entrées en **1 ligne**, alors que Projets/Learnings/Loisirs sont sur **2 lignes**.

**Cause** : Études portait `data-entries-layout='inline'` (défaut du paramètre `?entriesLayout`), là où les autres utilisent la grille `.cv-entry` de base (2 lignes).

**Fix** : le défaut du paramètre partagé passe de `inline` → `stacked` → Études rend 2 lignes (titre + année à droite, établissement en ligne 2), cohérent avec les autres. `?entriesLayout=inline` reste dispo pour repasser en 1 ligne.

- CV court inchangé (Études y passe par le chemin `condensed`) → **toujours 1 page A4**.
- lint + tsc + e2e 1-page (fr/en) verts. Vérifié : Études = `display:grid`, 2 lignes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)