### PR TITLE
fix(cv): harmonise la taille des dates (14px, toutes sections) via .cv-date

### DIFF
--- a/app/[lang]/projects.tsx
+++ b/app/[lang]/projects.tsx
@@ -90,7 +90,7 @@ export default async function projects({
               ) : null}
               {year ? (
                 // Date à la couleur de la section (comme les dates d'expérience).
-                <span className="cv-entry-year text-sm tabular-nums text-cv-tag-text print:!text-cv-tag-text">
+                <span className="cv-entry-year cv-date tabular-nums text-cv-tag-text print:!text-cv-tag-text">
                   {year}
                 </span>
               ) : null}

--- a/app/[lang]/studies.tsx
+++ b/app/[lang]/studies.tsx
@@ -83,7 +83,7 @@ export default async function studies({
               ) : null}
               {year ? (
                 // Date à la couleur de la section (comme les dates d'expérience).
-                <span className="cv-entry-year text-sm tabular-nums text-purple-300 print:!text-purple-300">
+                <span className="cv-entry-year cv-date tabular-nums text-purple-300 print:!text-purple-300">
                   {year}
                 </span>
               ) : null}

--- a/components/HobbiesDisplay.tsx
+++ b/components/HobbiesDisplay.tsx
@@ -59,7 +59,7 @@ export default function HobbiesDisplay({
               ) : null}
               {/* Année APRÈS le détail (ordre DOM cohérent avec Études). */}
               {period ? (
-                <span className="cv-entry-year tabular-nums text-orange-300 print:!text-orange-300">
+                <span className="cv-entry-year cv-date tabular-nums text-orange-300 print:!text-orange-300">
                   {period}
                 </span>
               ) : null}

--- a/components/JobDisplay.tsx
+++ b/components/JobDisplay.tsx
@@ -210,7 +210,7 @@ export default function JobDisplay({
             {job.location ? ` / ${job.location}` : ''}
           </span>
         </span>
-        <span className="min-w-max shrink-0 self-end text-cv-meta font-normal tabular-nums leading-snug text-cv-jobs print-preview:!inline print:!inline print:text-xs max-md:hidden">
+        <span className="cv-date min-w-max shrink-0 self-end font-normal tabular-nums leading-snug text-cv-jobs print-preview:!inline print:!inline max-md:hidden">
           {dates}
         </span>
       </div>

--- a/components/LearningsDisplay.tsx
+++ b/components/LearningsDisplay.tsx
@@ -63,7 +63,7 @@ export default function LearningsDisplay({
                   Études) : sans effet en grille (slot `year`), correct si un jour
                   l'entrée passe inline (le `·` s'attache à l'année, pas au détail). */}
               {period ? (
-                <span className="cv-entry-year tabular-nums text-teal-300 print:!text-teal-300">
+                <span className="cv-entry-year cv-date tabular-nums text-teal-300 print:!text-teal-300">
                   {period}
                 </span>
               ) : null}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -94,6 +94,16 @@
   --cv-section-body-gap: 0.5rem;
 }
 
+/* Taille UNIQUE des dates / années de TOUTES les sections du CV complet
+   (Expériences, Études, Projets, Learnings, Loisirs) → cohérence garantie et
+   pérenne. `!important` = source de vérité unique : une section ne peut plus
+   diverger accidentellement (avant : Expériences 12px, Études/Projets 14px,
+   Learnings/Loisirs 16px). 14px en web ET en impression. Le CV court garde ses
+   dates compactes propres (12px, éléments NON tagués `.cv-date`). */
+.cv-date {
+  font-size: 0.875rem !important; /* 14px */
+}
+
 @layer components {
   /**
    * Rythme vertical « section majeure » : 2.5rem (`mt-10` / `gap-10`).


### PR DESCRIPTION
Les dates du CV complet **divergeaient selon la section** :

| Section | Avant | Après |
|---|---|---|
| **Expériences** | **12px** (trop petites, ex. « 10/2019 - 05/2020 ») | **14px** |
| Études / Projets | 14px | 14px |
| Learnings / Loisirs | **16px** (année sans classe → héritée) | **14px** |

**Fix** : une classe **unique** `.cv-date { font-size: 0.875rem !important }` (14px, web ET print), taguée sur les 5 éléments date → **source de vérité unique**, plus aucune divergence possible entre sections (l'origine du problème dans tout ce chantier).

- CV court inchangé (dates compactes 12px, éléments non tagués) → **toujours 1 page**.
- En-têtes d'expérience **toujours sur 1 ligne** (le +2px de date ne fait pas déborder).
- Vérifié : toutes les dates à 14px web+print. lint + tsc + **12 e2e** verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)