### PR TITLE
feat(cv): macaron « adapter ce CV par IA » + page /[lang]/ai

### DIFF
--- a/app/[lang]/ai/page.tsx
+++ b/app/[lang]/ai/page.tsx
@@ -1,0 +1,182 @@
+import type { Metadata } from 'next';
+import { Locale } from '../../../i18n-config';
+import CopyPromptButton from '@/components/CopyPromptButton';
+
+/** URL publique canonique du CV (identique au guide `/api/llm-guide`). */
+const SITE = 'https://www.elzinko.fr';
+
+/** Prompt prêt-à-coller dans ChatGPT / Claude / etc. (une version par langue). */
+function buildPrompt(lang: Locale): string {
+  if (lang === 'fr') {
+    return `Tu es un assistant qui personnalise un CV en ligne à partir d'une offre d'emploi.
+
+Le CV de Thomas Couderc est public et dynamique :
+- Guide complet (endpoints + paramètres d'URL) : ${SITE}/api/llm-guide
+- Données structurées JSON : ${SITE}/api/profile?lang=fr
+
+Voici l'offre à laquelle je réponds :
+"""
+[COLLEZ ICI L'OFFRE D'EMPLOI]
+"""
+
+À partir de cette offre :
+1. Lis le guide et les données ci-dessus.
+2. Construis l'URL du CV adaptée, de la forme :
+   ${SITE}/fr?company=<entreprise>&title=<intitulé>&requirement=<Libellé:mots-clés>
+   – répète le paramètre requirement pour chaque compétence clé, les plus importantes en premier ;
+   – ajoute contract=cdi pour un poste permanent (freelance par défaut).
+3. Donne-moi : l'URL du CV complet, l'URL du CV court (…/fr/short?…), et un court paragraphe d'adéquation au poste.`;
+  }
+  return `You are an assistant that tailors an online CV to a job posting.
+
+Thomas Couderc's CV is public and dynamic:
+- Full guide (endpoints + URL parameters): ${SITE}/api/llm-guide
+- Structured JSON data: ${SITE}/api/profile?lang=en
+
+Here is the job posting I'm applying to:
+"""
+[PASTE THE JOB POSTING HERE]
+"""
+
+From this posting:
+1. Read the guide and data above.
+2. Build the tailored CV URL, shaped like:
+   ${SITE}/en?company=<company>&title=<title>&requirement=<Label:keywords>
+   – repeat the requirement parameter for each key skill, most important first;
+   – add contract=cdi for a permanent role (freelance by default).
+3. Give me: the full CV URL, the short CV URL (…/en/short?…), and a short fit paragraph.`;
+}
+
+const COPY = {
+  fr: {
+    title: 'Générez ce CV pour votre poste',
+    lead: 'Ce CV est dynamique : un assistant IA peut en produire une version taillée pour VOTRE offre, en quelques secondes. Aucune inscription, tout est public.',
+    stepsTitle: 'Comment faire',
+    steps: [
+      'Copiez le prompt ci-dessous.',
+      'Collez-le dans ChatGPT, Claude ou l’assistant de votre choix, avec le texte de votre offre d’emploi.',
+      'L’assistant vous renvoie un lien vers ce CV, adapté au poste (compétences mises en avant, expériences pertinentes en tête).',
+    ],
+    promptTitle: 'Le prompt',
+    copyIdle: 'Copier le prompt',
+    copyDone: 'Copié !',
+    guideNote: 'Pour les curieux et les agents : ',
+    guideLink: 'guide technique complet',
+    guideAria: 'Guide technique complet (Markdown)',
+    back: '← Revenir au CV',
+  },
+  en: {
+    title: 'Generate this CV for your role',
+    lead: 'This CV is dynamic: an AI assistant can produce a version tailored to YOUR job posting in seconds. No sign-up, everything is public.',
+    stepsTitle: 'How it works',
+    steps: [
+      'Copy the prompt below.',
+      'Paste it into ChatGPT, Claude or the assistant of your choice, along with your job posting.',
+      'The assistant returns a link to this CV, tailored to the role (relevant skills and experiences brought to the front).',
+    ],
+    promptTitle: 'The prompt',
+    copyIdle: 'Copy the prompt',
+    copyDone: 'Copied!',
+    guideNote: 'For the curious and for agents: ',
+    guideLink: 'full technical guide',
+    guideAria: 'Full technical guide (Markdown)',
+    back: '← Back to the CV',
+  },
+} as const;
+
+export function generateMetadata({
+  params: { lang },
+}: {
+  params: { lang: Locale };
+}): Metadata {
+  const t = COPY[lang] ?? COPY.fr;
+  return {
+    title: t.title,
+    description: t.lead,
+  };
+}
+
+export default function AiTailorPage({
+  params: { lang },
+}: {
+  params: { lang: Locale };
+}) {
+  const t = COPY[lang] ?? COPY.fr;
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  const prompt = buildPrompt(lang);
+
+  return (
+    <div className="mx-auto max-w-3xl max-md:pt-12">
+      <a
+        href={`${basePath}/${lang}`}
+        className="text-sm text-cv-section underline-offset-2 hover:underline"
+      >
+        {t.back}
+      </a>
+
+      <header className="mt-4">
+        <span className="inline-flex items-center gap-2 rounded-full border border-cv-section/40 bg-cv-section/5 px-3 py-1 text-xs font-medium text-cv-section">
+          <svg
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+            className="h-3.5 w-3.5"
+          >
+            <path d="M12 2l1.85 5.15L19 9l-5.15 1.85L12 16l-1.85-5.15L5 9l5.15-1.85L12 2z" />
+          </svg>
+          {lang === 'fr' ? 'CV adaptable par IA' : 'AI-tailorable CV'}
+        </span>
+        <h1 className="mt-3 text-3xl font-semibold text-slate-900">
+          {t.title}
+        </h1>
+        <p className="mt-2 max-w-2xl text-base leading-relaxed text-slate-600">
+          {t.lead}
+        </p>
+      </header>
+
+      <section className="mt-8">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+          {t.stepsTitle}
+        </h2>
+        <ol className="mt-3 space-y-3">
+          {t.steps.map((step, i) => (
+            <li key={i} className="flex gap-3">
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-cv-section text-xs font-semibold text-white">
+                {i + 1}
+              </span>
+              <span className="pt-0.5 text-slate-700">{step}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="mt-8">
+        <div className="mb-2 flex items-center justify-between gap-4">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+            {t.promptTitle}
+          </h2>
+          <CopyPromptButton
+            text={prompt}
+            idleLabel={t.copyIdle}
+            doneLabel={t.copyDone}
+          />
+        </div>
+        <pre className="max-h-96 overflow-auto whitespace-pre-wrap rounded-lg border border-slate-200 bg-slate-50 p-4 font-mono text-[0.8rem] leading-relaxed text-slate-800">
+          {prompt}
+        </pre>
+      </section>
+
+      <p className="mt-6 text-sm text-slate-500">
+        {t.guideNote}
+        <a
+          href={`${basePath}/api/llm-guide`}
+          aria-label={t.guideAria}
+          className="text-cv-section underline underline-offset-2 hover:text-teal-600"
+        >
+          {t.guideLink}
+        </a>
+        .
+      </p>
+    </div>
+  );
+}

--- a/app/[lang]/layout.tsx
+++ b/app/[lang]/layout.tsx
@@ -3,6 +3,7 @@ import { i18n, type Locale } from '../../i18n-config';
 import { Analytics } from '@vercel/analytics/react';
 import CvMobilePreviewOverlay from '@/components/CvMobilePreviewOverlay';
 import DevNav from '@/components/DevNav';
+import AiTailorMacaron from '@/components/AiTailorMacaron';
 
 export async function generateStaticParams() {
   return i18n.locales.map((locale) => ({ lang: locale }));
@@ -45,6 +46,9 @@ export default async function RootLayout({
       <div className="container mx-auto min-h-screen p-8 print:min-h-0 print:px-8 print:py-0 max-md:px-4 max-md:pb-8 max-md:pt-3">
         <main>{children}</main>
       </div>
+      {/* Macaron flottant « adapter ce CV par IA » → `/{lang}/ai`. Écran uniquement
+          (masqué print + aperçu), hors flux DOM du CV. Voir AiTailorMacaron. */}
+      <AiTailorMacaron lang={lang} />
       {/* Nav dev vers les pages internes — hors production uniquement (absente du
           DOM en prod, même gating que le middleware qui 404 les /dev/* en prod). */}
       {isDev && <DevNav lang={lang} />}

--- a/components/AiTailorMacaron.tsx
+++ b/components/AiTailorMacaron.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import type { Locale } from '../i18n-config';
+
+/**
+ * Macaron flottant (écran uniquement) invitant le visiteur à générer une version
+ * du CV adaptée à SON offre via un LLM. Pointe vers la page publique `/{lang}/ai`.
+ *
+ * - **Autonome** : rendu une seule fois dans `app/[lang]/layout.tsx`, en `position: fixed`
+ *   → hors du flux DOM du CV, aucun impact possible sur les 4 rendus (invariant WYSIWYG).
+ * - **Masqué à l'impression ET en aperçu** (`print:hidden` + `print-preview:hidden`) :
+ *   un bouton cliquable n'a aucun sens sur un PDF (règle « pas de print orphelin »).
+ * - **Coin bas-droit** : le curseur de zoom (`CvZoomSlider`) occupe déjà le haut-droit sur
+ *   `/short` (desktop) → on ne se marche pas dessus.
+ * - **Caché sur `/{lang}/ai`** (auto-référence) **et sur `/{lang}/dev/*`** (outils internes).
+ */
+export default function AiTailorMacaron({ lang }: { lang: Locale }) {
+  const pathname = usePathname();
+  if (pathname?.endsWith('/ai') || pathname?.includes('/dev/')) return null;
+
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  const label =
+    lang === 'fr'
+      ? 'Adapter ce CV à votre offre'
+      : 'Tailor this CV to your job';
+  const title =
+    lang === 'fr'
+      ? 'Générez une version de ce CV taillée pour votre poste, avec une IA'
+      : 'Generate a version of this CV tailored to your role, with an AI';
+
+  return (
+    <a
+      href={`${basePath}/${lang}/ai`}
+      title={title}
+      data-testid="ai-tailor-macaron"
+      className="group fixed bottom-4 right-4 z-[110] inline-flex items-center gap-2 rounded-full border border-cv-section/40 bg-white/90 px-3 py-2 text-xs font-medium text-slate-700 shadow-lg backdrop-blur transition duration-200 hover:-translate-y-0.5 hover:border-cv-section hover:text-cv-section hover:shadow-xl print-preview:hidden supports-[backdrop-filter]:bg-white/75 print:hidden md:px-4 md:text-sm"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true"
+        className="h-4 w-4 text-cv-section transition-transform duration-200 group-hover:rotate-12"
+      >
+        <path d="M12 2l1.85 5.15L19 9l-5.15 1.85L12 16l-1.85-5.15L5 9l5.15-1.85L12 2z" />
+        <path
+          d="M19 13.5l.9 2.1 2.1.9-2.1.9-.9 2.1-.9-2.1-2.1-.9 2.1-.9.9-2.1z"
+          opacity="0.6"
+        />
+      </svg>
+      <span>{label}</span>
+    </a>
+  );
+}

--- a/components/CopyPromptButton.tsx
+++ b/components/CopyPromptButton.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+/**
+ * Bouton « copier le prompt » : copie `text` dans le presse-papier et affiche un
+ * retour transitoire (« Copié ! ») pendant ~2 s. Autonome, sans dépendance.
+ */
+export default function CopyPromptButton({
+  text,
+  idleLabel,
+  doneLabel,
+}: {
+  text: string;
+  idleLabel: string;
+  doneLabel: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Presse-papier indisponible (contexte non sécurisé / permission) : on
+      // sélectionne le texte en repli pour un copier manuel.
+      return;
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      data-testid="copy-prompt"
+      aria-live="polite"
+      className="inline-flex items-center gap-2 rounded-lg bg-cv-section px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-teal-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-cv-section focus-visible:ring-offset-2"
+    >
+      {copied ? (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+          className="h-4 w-4"
+        >
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      ) : (
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+          className="h-4 w-4"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+      <span>{copied ? doneLabel : idleLabel}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
Un macaron flottant « stylé » invite le visiteur à **générer une version du CV taillée pour son offre via un LLM**, et le mène à une page publique qui explique comment faire.

## Pourquoi une page dédiée
Les deux surfaces « llm-guide » existantes ne conviennent pas à un humain : `/api/llm-guide` = markdown machine brut, `/[lang]/dev/llm-guide` = `noindex` **et 404 en prod**. Cette PR crée le point d'entrée **public et humain** qui manquait — tout en pointant vers le guide technique complet pour les curieux/agents.

## Contenu
- **`app/[lang]/ai/page.tsx`** — page publique **statique (SSG `/fr/ai` + `/en/ai`)**, bilingue : pitch + 3 étapes + **prompt prêt-à-coller** (bouton « copier ») + lien vers `/api/llm-guide`.
- **`components/AiTailorMacaron.tsx`** — macaron flottant monté une fois dans `app/[lang]/layout.tsx`. `position: fixed` (hors flux DOM du CV), **écran uniquement** (`print:hidden` + `print-preview:hidden`), coin bas-droit, auto-masqué sur `/ai` et `/dev/*`.
- **`components/CopyPromptButton.tsx`** — copie presse-papier + retour « Copié ! ».

## Vérification
`tsc` OK, `build` OK (/ai en SSG fr+en), Playwright OK : macaron bas-droit sur /fr + mobile (aucune collision), /fr/ai et /en/ai rendus + macaron auto-masqué, bouton copier OK, apercu ?print=1 masque le macaron, 0 erreur console.

Independante du lot de nettoyage #160. A previsualiser sur le deploiement preview Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)